### PR TITLE
publish aar to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
   only:
     - master
     - develop
-    - /^v\d+\.\d+\.\d+$/
+    - /^v-\d+\.\d+\.\d+$/
 
 stages:
   - name: Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,12 @@ jobs:
         - docker
       env:
         - DIST=android JAVA_VERSION=8 ANDROID_API=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=21.1.6352462 ROC_BASE_DIR=$HOME/roc
+      workspaces:
+        create:
+          name: android
+          paths:
+            - android
+            - $ROC_BASE_DIR
     - name: "android jdk11"
       stage: Android
       sudo: required
@@ -73,10 +79,13 @@ jobs:
         - DIST=android JAVA_VERSION=11 ANDROID_API=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=21.1.6352462 ROC_BASE_DIR=$HOME/roc
     - name: "android release"
       stage: Release
+      workspaces:
+        use: android
       services:
         - docker
       env:
         - DIST=android JAVA_VERSION=8 ANDROID_API=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=21.1.6352462 ROC_BASE_DIR=$HOME/roc
+      install: echo 'skip install'
       script: scripts/travis/android/publish.sh
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ branches:
   only:
     - master
     - develop
+    - /^v\d+\.\d+\.\d+$/
 
 stages:
   - name: Linux
   - name: macOS
   - name: Android
+  - name: Release
+    if: tag IS present
 
 jobs:
   include:
@@ -68,6 +71,14 @@ jobs:
         - docker
       env:
         - DIST=android JAVA_VERSION=11 ANDROID_API=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=21.1.6352462 ROC_BASE_DIR=$HOME/roc
+    - name: "android release"
+      stage: Release
+      services:
+        - docker
+      env:
+        - DIST=android JAVA_VERSION=8 ANDROID_API=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=21.1.6352462 ROC_BASE_DIR=$HOME/roc
+      script: scripts/travis/android/publish.sh
+
 
 before_install:
   - if [ ! -z $DIST ]; then scripts/travis/$DIST/before_install.sh; else scripts/travis/$TRAVIS_OS_NAME/before_install.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
   only:
     - master
     - develop
-    - /^v-\d+\.\d+\.\d+$/
+    - /^v\d+\.\d+\.\d+$/
 
 stages:
   - name: Linux

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ If libroc is not in default path you can specify `ROC_INCLUDE_PATH` (path to roc
 
 Additional compilation and linking flags can be specified respectively with `CFLAGS` and `LDFLAGS` gradle system variables
 
+#### Release
+
+Release workflow:
+ * make sure, that right version has been set in 'build.gradle' file, e.g. `0.0.1`
+ * make github release with that version, e.g. `v0.0.1`
+ * travis will run release stage and publish artifacts to bintray
+
+Followed env variables should be set in travis:
+ * `BINTRAY_USER` - bintray user
+ * `BINTRAY_KEY` - bintray user api key
+ * `BINTRAY_REPO` - bintray repository name
+ * `BINTRAY_REPO_ORG` - bintray organization name
+
 ## License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Additional compilation and linking flags can be specified respectively with `CFL
 #### Android Release
 
 Release workflow:
- * make github release with tag version `v-x.x.x`, e.g. `v-0.0.1`
+ * make github release with tag version, e.g. `v0.0.1`
  * travis will run release stage and publish artifacts to bintray
 
 Followed env variables should be set in travis:

--- a/README.md
+++ b/README.md
@@ -43,11 +43,10 @@ If libroc is not in default path you can specify `ROC_INCLUDE_PATH` (path to roc
 
 Additional compilation and linking flags can be specified respectively with `CFLAGS` and `LDFLAGS` gradle system variables
 
-#### Release
+#### Android Release
 
 Release workflow:
- * make sure, that right version has been set in 'build.gradle' file, e.g. `0.0.1`
- * make github release with that version, e.g. `v0.0.1`
+ * make github release with tag version `v-x.x.x`, e.g. `v-0.0.1`
  * travis will run release stage and publish artifacts to bintray
 
 Followed env variables should be set in travis:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+apply from: '../tag_version.gradle'
+
 buildscript {
     repositories {
         google()
@@ -13,13 +15,9 @@ buildscript {
     }
 }
 
-plugins {
-    id 'com.palantir.git-version' version '0.12.3'
-}
-
 allprojects {
     group 'org.rocstreaming.roctoolkit'
-    version gitVersion(prefix:'v-')
+    version tagVersion
 
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,11 +7,16 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.5.2.0"
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.5.2.0'
     }
 }
 
 allprojects {
+    group 'org.rocstreaming.roctoolkit'
+    version '0.0.1'
+
     repositories {
         google()
         jcenter()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,15 +13,18 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.palantir.git-version' version '0.12.3'
+}
+
 allprojects {
     group 'org.rocstreaming.roctoolkit'
-    version '0.0.1'
+    version gitVersion(prefix:'v-')
 
     repositories {
         google()
         jcenter()
         mavenCentral()
-        
     }
 }
 

--- a/android/roc-android/build.gradle
+++ b/android/roc-android/build.gradle
@@ -119,6 +119,12 @@ bintray {
         licenses = ["MIT"]
         publish = true
         publicDownloadNumbers = true
+
+        version {
+            gpg {
+                sign = true
+            }
+        }
     }
 }
 

--- a/android/roc-android/build.gradle
+++ b/android/roc-android/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'com.android.library'
+    id 'com.github.dcendents.android-maven'
+    id 'com.jfrog.bintray'
     id 'de.mannodermaus.android-junit5'
 }
 
@@ -8,6 +10,10 @@ ext {
     buildToolsVersion = System.getProperty('BUILD_TOOLS_VERSION') ?: System.getenv('BUILD_TOOLS_VERSION')
     androidNdkVersion = System.getProperty('NDK_VERSION') ?: System.getenv('NDK_VERSION')
     ROC_BASE_DIR = System.getProperty('ROC_BASE_DIR') ?: System.getenv('ROC_BASE_DIR')
+    bintrayUser = System.getProperty('BINTRAY_USER') ?: System.getenv('BINTRAY_USER')
+    bintrayKey = System.getProperty('BINTRAY_KEY') ?: System.getenv('BINTRAY_KEY')
+    bintrayRepo = System.getProperty('BINTRAY_REPO') ?: System.getenv('BINTRAY_REPO')
+    bintrayRepoOrg = System.getProperty('BINTRAY_REPO_ORG') ?: System.getenv('BINTRAY_REPO_ORG')
 }
 
 android {
@@ -74,4 +80,69 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.2"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.2"
+}
+
+task sourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+}
+
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+bintray {
+    user = bintrayUser
+    key = bintrayKey
+
+    pkg {
+        repo = bintrayRepo
+        name = project.name
+        userOrg = bintrayRepoOrg
+        configurations = ['archives']
+        desc = 'Android library for Roc Toolkit'
+        websiteUrl = 'https://github.com/roc-streaming/roc-java'
+        issueTrackerUrl = 'https://github.com/roc-streaming/roc-java/issues'
+        vcsUrl = 'https://github.com/roc-streaming/roc-java.git'
+        licenses = ["MIT"]
+        publish = true
+        publicDownloadNumbers = true
+    }
+}
+
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                packaging 'aar'
+                name 'roc-android'
+                description 'Android library for Roc Toolkit'
+                url 'https://github.com/roc-streaming/roc-java'
+
+                licenses {
+                    license {
+                        name 'MIT'
+                    }
+                }
+
+                scm {
+                    connection 'scm:git:https://github.com/roc-streaming/roc-java.git'
+                    developerConnection 'scm:git:https://github.com/roc-streaming/roc-java.git'
+                    url 'https://github.com/roc-streaming/roc-java'
+                }
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,11 @@ plugins {
     id 'com.adarshr.test-logger' version '2.0.0'
 }
 
+apply from: 'tag_version.gradle'
+
 allprojects {
     group 'org.rocstreaming.roctoolkit'
-    version '0.0.1'
+    version tagVersion
 }
 
 repositories {

--- a/scripts/travis/android/entrypoint/publish.sh
+++ b/scripts/travis/android/entrypoint/publish.sh
@@ -4,5 +4,5 @@ set -euxo pipefail
 export TERM=dumb
 
 cd android
-./gradlew build bintrayUpload
+./gradlew bintrayUpload
 

--- a/scripts/travis/android/entrypoint/publish.sh
+++ b/scripts/travis/android/entrypoint/publish.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euxo pipefail
+
+export TERM=dumb
+
+cd android
+./gradlew build bintrayUpload
+

--- a/scripts/travis/android/publish.sh
+++ b/scripts/travis/android/publish.sh
@@ -12,5 +12,5 @@ docker run -t --rm --privileged --device /dev/kvm \
     --env BINTRAY_REPO_ORG=$BINTRAY_REPO_ORG \
     -v "${PWD}:${PWD}" -v $ROC_BASE_DIR:$ROC_BASE_DIR \
     -v android-sdk:/sdk -w "${PWD}" \
-        rocproject/java-android:jdk$JAVA_VERSION \
+        rocstreaming/env-android:jdk$JAVA_VERSION \
             $PWD/scripts/travis/android/entrypoint/publish.sh

--- a/scripts/travis/android/publish.sh
+++ b/scripts/travis/android/publish.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+docker run -t --rm --privileged --device /dev/kvm \
+    --env API=$ANDROID_API \
+    --env BUILD_TOOLS_VERSION=$ANDROID_BUILD_TOOLS_VERSION \
+    --env NDK_VERSION=$ANDROID_NDK_VERSION \
+    --env ROC_BASE_DIR=$ROC_BASE_DIR \
+    --env BINTRAY_USER=$BINTRAY_USER \
+    --env BINTRAY_KEY=$BINTRAY_KEY \
+    --env BINTRAY_REPO=$BINTRAY_REPO \
+    --env BINTRAY_REPO_ORG=$BINTRAY_REPO_ORG \
+    -v "${PWD}:${PWD}" -v $ROC_BASE_DIR:$ROC_BASE_DIR \
+    -v android-sdk:/sdk -w "${PWD}" \
+        rocproject/java-android:jdk$JAVA_VERSION \
+            $PWD/scripts/travis/android/entrypoint/publish.sh

--- a/tag_version.gradle
+++ b/tag_version.gradle
@@ -1,0 +1,17 @@
+def getTagVersion = {
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine "git", "describe", "--tags", "--match", "v*"
+            standardOutput = stdout
+        }
+        def tag = stdout.toString().trim()
+        return tag.substring(1)
+    } catch (exception) {
+        return "SNAPSHOT"
+    }
+}
+
+ext {
+    tagVersion = getTagVersion()
+}


### PR DESCRIPTION
Publish aar to bintray #19 

Current release workflow:

* make sure in 'build.gradle' file right version has been set, e.g. `0.0.1`
* make github release with that version, e.g. `v0.0.1`
* travis will run release stage and publish artifacts to bintray

I've added env variables to travis to publish into https://bintray.com/roc-streaming/maven repo