### PR TITLE
Very important change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JNI bindings for Roc Toolkit
 
 [![Build Status](https://travis-ci.org/roc-streaming/roc-java.svg?branch=master)](https://travis-ci.org/roc-streaming/roc-java)
-[![Download](https://api.bintray.com/packages/roc-streaming/maven/roc-android/images/download.svg) ](https://bintray.com/roc-streaming/maven/roc-android/_latestVersion)
+![Android release](https://img.shields.io/bintray/v/roc-streaming/maven/roc-android?color=blue&label=android)
 
 _Work in progress!_
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JNI bindings for Roc Toolkit
 
 [![Build Status](https://travis-ci.org/roc-streaming/roc-java.svg?branch=master)](https://travis-ci.org/roc-streaming/roc-java)
-![Android release](https://img.shields.io/bintray/v/roc-streaming/maven/roc-android?color=blue&label=android)
+[![Android release](https://img.shields.io/bintray/v/roc-streaming/maven/roc-android?color=blue&label=android)](https://bintray.com/roc-streaming/maven/roc-android/_latestVersion)
 
 _Work in progress!_
 


### PR DESCRIPTION
Change bintray badge to this: https://img.shields.io/bintray/v/roc-streaming/maven/roc-android?color=blue&label=android

(From here: https://shields.io/category/version)

The new one is named "android" because the badge and its link are actually android-specific.

PS. The word "android" can be replaced to something else if desired, e.g. with "aar".