### PR TITLE
Finalizer-like feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
   only:
     - master
     - develop
+    - /^feature\/.*/
     - /^v\d+\.\d+\.\d+$/
 
 stages:

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
     platform = System.getProperty("platform") ?: os
     architecture = System.getProperty("host") ?: System.getProperty("os.arch")
     targetLibraryPath = "${project.buildDir}/libs/${platform}/${architecture}"
-    nativeHeadersPath = "${project.rootDir}/${System.properties["rocJniLibraryName"]}/src/main/public"
+    nativeHeadersPath = project(":roc_jni").projectDir.getAbsolutePath() + "/src/main/public"
 }
 
 task generateHeaders(dependsOn: 'classes') {
@@ -51,9 +51,9 @@ task generateHeaders(dependsOn: 'classes') {
 }
 
 task copyNativeDeps(type: Copy) {
-    from("${project.rootDir}/${System.properties["rocJniLibraryName"]}/build/lib/main/debug")
+    from(project(":roc_jni").buildDir.getAbsolutePath() + "/lib/main/debug")
     into targetLibraryPath
-    dependsOn ":${System.properties["rocJniLibraryName"]}:build"
+    dependsOn ":roc_jni:build"
 }
 
 jar.dependsOn copyNativeDeps
@@ -75,7 +75,8 @@ testlogger {
 }
 
 javadoc {
-    options.overview = "docs/javadoc/overview.html"
+    options.overview = "${project.rootDir}/docs/javadoc/overview.html"
+    options.memberLevel = System.getProperty("visibility") == "private" ? JavadocMemberLevel.PRIVATE : JavadocMemberLevel.PUBLIC
 }
 
 static def getOsName() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-systemProp.rocJniLibraryName=roc_jni

--- a/roc_jni/src/main/cpp/common.cpp
+++ b/roc_jni/src/main/cpp/common.cpp
@@ -60,9 +60,3 @@ jobject get_object_field(JNIEnv *env, jclass clazz, jobject obj, const char* att
     assert(attrId != NULL);
     return env->GetObjectField(obj, attrId);
 }
-
-void set_native_pointer(JNIEnv *env, jclass clazz, jobject native_obj, void* ptr) {
-    jfieldID attrId = env->GetFieldID(clazz, "ptr", "J");
-    assert(attrId != NULL);
-    env->SetLongField(native_obj, attrId, (jlong) ptr);
-}

--- a/roc_jni/src/main/cpp/context.cpp
+++ b/roc_jni/src/main/cpp/context.cpp
@@ -21,36 +21,26 @@ char context_config_unmarshall(JNIEnv *env, roc_context_config* conf, jobject jc
     return err;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Context_open(JNIEnv *env, jobject thisObj, jobject config) {
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Context_open(JNIEnv *env, jclass contextClass, jobject config) {
     roc_context*        context;
     roc_context_config  context_config;
-    jclass              contextClass;
-
-    if (config == NULL) {
-        jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Wrong context configuration values");
-        return;
-    }
-
-    contextClass = env->FindClass(CONTEXT_CLASS);
-    assert(contextClass != NULL);
 
     if (context_config_unmarshall(env, &context_config, config) != 0) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
         env->ThrowNew(exceptionClass, "Wrong context configuration values");
-        return;
+        return (jlong) NULL;
     }
 
     if ((context = roc_context_open(&context_config)) == NULL) {
         jclass exceptionClass = env->FindClass(EXCEPTION);
         env->ThrowNew(exceptionClass, "Error opening context");
-        return;
+        return (jlong) NULL;
     }
 
-    set_native_pointer(env, contextClass, thisObj, context);
+    return (jlong) context;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Context_close(JNIEnv *env, jobject thisObj, jlong nativePtr) {
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Context_close(JNIEnv *env, jclass contextClass, jlong nativePtr) {
 
     roc_context* context = (roc_context*) nativePtr;
 

--- a/roc_jni/src/main/cpp/receiver.cpp
+++ b/roc_jni/src/main/cpp/receiver.cpp
@@ -50,37 +50,27 @@ char receiver_config_unmarshall(JNIEnv *env, roc_receiver_config* config, jobjec
     return err;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_open(JNIEnv * env, jobject thisObj,
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Receiver_open(JNIEnv * env, jclass receiverClass,
                     jlong contextPtr, jobject jconfig) {
     roc_context*            context;
     roc_receiver_config     receiverConfig;
     roc_receiver*           receiver;
-    jclass                  receiverClass;
-
-    if (jconfig == NULL) {
-        jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Bad arguments");
-        return;
-    }
-
-    receiverClass = env->FindClass(RECEIVER_CLASS);
-    assert(receiverClass != NULL);
 
     context = (roc_context*) contextPtr;
 
     if (receiver_config_unmarshall(env, &receiverConfig, jconfig) != 0) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
         env->ThrowNew(exceptionClass, "Bad arguments");
-        return;
+        return (jlong) NULL;
     }
 
     if ((receiver = roc_receiver_open(context, &receiverConfig)) == NULL) {
         jclass exceptionClass = env->FindClass(EXCEPTION);
         env->ThrowNew(exceptionClass, "Error opening receiver");
-        return;
+        return (jlong) NULL;
     }
 
-    set_native_pointer(env, receiverClass, thisObj, receiver);
+    return (jlong) receiver;
 }
 
 JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_bind(JNIEnv * env, jobject thisObj, jlong receiverPtr,
@@ -146,7 +136,7 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_readFloats(JNIE
     env->ReleaseFloatArrayElements(jsamples, samples, 0);
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_close(JNIEnv *env, jobject thisObj, jlong receiverPtr) {
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_close(JNIEnv *env, jclass receiverClass, jlong receiverPtr) {
 
     roc_receiver* receiver = (roc_receiver*) receiverPtr;
 

--- a/roc_jni/src/main/cpp/sender.cpp
+++ b/roc_jni/src/main/cpp/sender.cpp
@@ -60,39 +60,29 @@ char sender_config_unmarshall(JNIEnv *env, roc_sender_config* config, jobject jc
     return err;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_open(JNIEnv *env, jobject thisObj, jlong contextPtr, jobject jconfig) {
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Sender_open(JNIEnv *env, jclass senderClass, jlong contextPtr, jobject jconfig) {
     roc_context*            context;
     roc_sender_config       config;
     roc_sender*             sender;
-    jclass                  senderClass;
-
-    if (jconfig == NULL) {
-        jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Bad arguments");
-        return;
-    }
-
-    senderClass = env->FindClass(SENDER_CLASS);
-    assert(senderClass != NULL);
 
     context = (roc_context*) contextPtr;
 
     if (sender_config_unmarshall(env, &config, jconfig) != 0) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
         env->ThrowNew(exceptionClass, "Bad arguments");
-        return;
+        return (jlong) NULL;
     }
 
     if ((sender = roc_sender_open(context, &config)) == NULL) {
         jclass exceptionClass = env->FindClass(EXCEPTION);
         env->ThrowNew(exceptionClass, "Error opening sender");
-        return;
+        return (jlong) NULL;
     }
 
-    set_native_pointer(env, senderClass, thisObj, sender);
+    return (jlong) sender;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_close(JNIEnv *env, jobject thisObj, jlong senderPtr) {
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_close(JNIEnv *env, jclass senderClass, jlong senderPtr) {
 
     roc_sender* sender = (roc_sender*) senderPtr;
 

--- a/roc_jni/src/main/headers/common.h
+++ b/roc_jni/src/main/headers/common.h
@@ -24,7 +24,6 @@ unsigned int get_uint_field_value(JNIEnv *env, jclass clazz, jobject obj, const 
 long long get_llong_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error);
 unsigned long long get_ullong_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error);
 
-void set_native_pointer(JNIEnv *env, jclass clazz, jobject native_obj, void* ptr);
 void set_int_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, int value);
 
 int get_enum_value(JNIEnv *env, jclass clazz, jobject enumObj);

--- a/roc_jni/src/main/public/org_rocstreaming_roctoolkit_Context.h
+++ b/roc_jni/src/main/public/org_rocstreaming_roctoolkit_Context.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     org_rocstreaming_roctoolkit_Context
  * Method:    open
- * Signature: (Lorg/rocstreaming/roctoolkit/ContextConfig;)V
+ * Signature: (Lorg/rocstreaming/roctoolkit/ContextConfig;)J
  */
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Context_open
-  (JNIEnv *, jobject, jobject);
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Context_open
+  (JNIEnv *, jclass, jobject);
 
 /*
  * Class:     org_rocstreaming_roctoolkit_Context
@@ -21,7 +21,7 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Context_open
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Context_close
-  (JNIEnv *, jobject, jlong);
+  (JNIEnv *, jclass, jlong);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/public/org_rocstreaming_roctoolkit_Receiver.h
+++ b/roc_jni/src/main/public/org_rocstreaming_roctoolkit_Receiver.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     org_rocstreaming_roctoolkit_Receiver
  * Method:    open
- * Signature: (JLorg/rocstreaming/roctoolkit/ReceiverConfig;)V
+ * Signature: (JLorg/rocstreaming/roctoolkit/ReceiverConfig;)J
  */
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_open
-  (JNIEnv *, jobject, jlong, jobject);
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Receiver_open
+  (JNIEnv *, jclass, jlong, jobject);
 
 /*
  * Class:     org_rocstreaming_roctoolkit_Receiver
@@ -37,7 +37,7 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_readFloats
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_close
-  (JNIEnv *, jobject, jlong);
+  (JNIEnv *, jclass, jlong);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/public/org_rocstreaming_roctoolkit_Sender.h
+++ b/roc_jni/src/main/public/org_rocstreaming_roctoolkit_Sender.h
@@ -10,10 +10,10 @@ extern "C" {
 /*
  * Class:     org_rocstreaming_roctoolkit_Sender
  * Method:    open
- * Signature: (JLorg/rocstreaming/roctoolkit/SenderConfig;)V
+ * Signature: (JLorg/rocstreaming/roctoolkit/SenderConfig;)J
  */
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_open
-  (JNIEnv *, jobject, jlong, jobject);
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Sender_open
+  (JNIEnv *, jclass, jlong, jobject);
 
 /*
  * Class:     org_rocstreaming_roctoolkit_Sender
@@ -45,7 +45,7 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_writeFloats
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_close
-  (JNIEnv *, jobject, jlong);
+  (JNIEnv *, jclass, jlong);
 
 #ifdef __cplusplus
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'roc-java'
 
-include ":${System.properties["rocJniLibraryName"]}"
+include ":roc_jni"

--- a/src/main/java/org/rocstreaming/roctoolkit/Address.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/Address.java
@@ -7,7 +7,7 @@ package org.rocstreaming.roctoolkit;
  *
  * @see Family
  */
-public class Address extends NativeObject {
+public class Address  {
 
     private Family family;
     private String ip;
@@ -37,7 +37,6 @@ public class Address extends NativeObject {
      *
      */
     public Address(Family family, String ip, int port) {
-        super();
         if (family == null || ip == null) throw new IllegalArgumentException();
         this.family = family;
         this.ip = ip;

--- a/src/main/java/org/rocstreaming/roctoolkit/AutoCloseThread.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/AutoCloseThread.java
@@ -1,0 +1,131 @@
+package org.rocstreaming.roctoolkit;
+
+import java.lang.ref.ReferenceQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Thread collecting references and closing {@link NativeObject}s when they become phantom reachable.
+ */
+class AutoCloseThread extends Thread {
+
+    /**
+     * Singleton instance.
+     */
+    private final static AutoCloseThread instance = new AutoCloseThread();
+
+    /**
+     * Queue of phantom reachable {@link NativeObject}.
+     */
+    private final ReferenceQueue<NativeObject> referenceQueue;
+
+    /**
+     * Collection of {@link NativeObjectReference} to avoid they get garbage collected.
+     */
+    private final ReferenceCollector<NativeObjectReference> phantomCollector;
+
+    /**
+     * Thread running flag.
+     */
+    private final AtomicBoolean running;
+
+    /**
+     * Create a new <code>AutoCloseThread</code>.
+     */
+    private AutoCloseThread() {
+        referenceQueue = new ReferenceQueue<>();
+        phantomCollector = new ReferenceCollector<>();
+        running = new AtomicBoolean(false);
+    }
+
+    /**
+     * Get <code>AutoCloseThread</code> instance.
+     *
+     * @return the <code>AutoCloseThread</code> singleton instance.
+     */
+    static AutoCloseThread getInstance() {
+        return instance;
+    }
+
+    /**
+     * Get thread running flag.
+     *
+     * @return  true if <code>AutoCloseThread</code> is currently running,
+     *          false otherwise.
+     */
+    boolean isRunning() {
+        return running.get();
+    }
+
+    /**
+     * Add a {@link NativeObject} to <code>AutoCloseThread</code>.
+     *
+     * @param nativeObj     {@link NativeObject} to add.
+     * @param dependsOn     {@link NativeObject} dependency.
+     *
+     * @return              the new {@link NativeObjectReference} associated to the {@link NativeObject}.
+     */
+    NativeObjectReference add(NativeObject nativeObj, NativeObject dependsOn) {
+        NativeObjectReference reference = new NativeObjectReference(nativeObj, dependsOn, referenceQueue);
+        phantomCollector.add(reference);
+        return reference;
+    }
+
+    /**
+     * Add a {@link NativeObject} to <code>AutoCloseThread</code>.
+     *
+     * @param nativeObj     {@link NativeObject} to add.
+     *
+     * @return              the new {@link NativeObjectReference} associated to the {@link NativeObject}.
+     */
+    NativeObjectReference add(NativeObject nativeObj) {
+        return add(nativeObj, null);
+    }
+
+    /**
+     * Remove a reference from <code>AutoCloseThread</code>.
+     *
+     * @param reference     the {@link NativeObjectReference} to remove.
+     */
+    void remove(NativeObjectReference reference) {
+        phantomCollector.remove(reference);
+    }
+
+    /**
+     * Entrypoint method of <code>AutoCloseThread</code>.
+     *
+     * Polls the {@link ReferenceQueue} associated to this <code>AutoCloseThread</code>
+     * and <code>close</code> any {@link NativeObjectReference} when it becomes phantom reachable.
+     */
+    @Override
+    public void run() {
+        running.set(true);
+        while (isRunning()) {
+            NativeObjectReference reference;
+            synchronized (this) {
+                if ((reference = (NativeObjectReference) referenceQueue.poll()) != null) {
+                    try {
+                        remove(reference);
+                        reference.close();
+                    } catch (Exception e) {
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Close all {@link NativeObjectReference} that are still open.
+     */
+    void closeAll() {
+        running.set(false);
+        synchronized (this) {
+            phantomCollector.iterator().forEachRemaining((reference) -> {
+                try {
+                    remove(reference);
+                    reference.close();
+                } catch (Exception e) {
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/org/rocstreaming/roctoolkit/Context.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/Context.java
@@ -3,24 +3,39 @@ package org.rocstreaming.roctoolkit;
 /**
  * Roc context.
  *
- * Context contains memory pools and network worker thread(s). Other objects that work
- * with memory and network should be attached to a context. It is allowed both to create
- * a separate context for every object, or to create a single context shared between
- * multiple objects.
+ * Context contains memory pools and network worker thread(s). Other objects
+ * that work with memory and network should be attached to a context. It is
+ * allowed both to create a separate context for every object, or to create a
+ * single context shared between multiple objects.
  *
  * A context is created using {@link #Context() Context()} or
  * {@link #Context(ContextConfig) Context(ContextConfig)} and destroyed using
- * {@link #close() close}.
- * <code>Receiver</code> class implements {@link AutoCloseable AutoCloseable} so if it is used in a
- * try-with-resources statement the object is closed automatically at the end of the statement.
- * Objects can be attached and detached to an opened context at any moment from any
- * thread. However, the user should ensure that the context is not closed until there
- * are no objects attached to the context.
+ * {@link #close() close()}. <code>Receiver</code> class implements
+ * {@link AutoCloseable AutoCloseable} so if it is used in a try-with-resources
+ * statement the object is closed automatically at the end of the statement.
+ * Objects can be attached and detached to an opened context at any moment from
+ * any thread. However, the user should ensure that the context is not closed
+ * until there are no objects attached to the context.
  *
  * @see Sender
  * @see Receiver
  */
-public class Context extends NativeObject implements AutoCloseable {
+public class Context extends NativeObject {
+
+    /**
+     * Validate context constructor parameters and open a new context if validation is successful.
+     *
+     * @param config                        should point to an initialized config.
+     *
+     * @return                              the native roc context pointer.
+     *
+     * @throws IllegalArgumentException     if the arguments are invalid.
+     * @throws Exception                    if there are not enough resources.
+     */
+    private static long validate(ContextConfig config) throws IllegalArgumentException, Exception {
+        if (config == null) throw new IllegalArgumentException();
+        return open(config);
+    }
 
     /**
      * Open a new context.
@@ -44,27 +59,11 @@ public class Context extends NativeObject implements AutoCloseable {
      * @throws IllegalArgumentException if the arguments are invalid.
      * @throws Exception if there are not enough resources.
      */
-    public Context(ContextConfig config) throws Exception {
-        super();
-        open(config);
+    public Context(ContextConfig config) throws IllegalArgumentException, Exception {
+        super(validate(config), Context::close);
     }
 
-    /**
-     * Close the context.
-     *
-     * Stops any started background threads, deinitializes and deallocates the context.
-     * The user should ensure that nobody uses the context during and after this call.
-     *
-     * If this function fails, the context is kept opened.
-     *
-     * @throws Exception if there are objects attached to the context.
-     */
-    @Override
-    public void close() throws Exception {
-        close(getPtr());
-    }
-
-    private native void open(ContextConfig config) throws Exception;
-    private native void close(long nativePtr) throws Exception;
+    private static native long open(ContextConfig config) throws IllegalArgumentException, Exception;
+    private static native void close(long nativePtr) throws Exception;
 }
 

--- a/src/main/java/org/rocstreaming/roctoolkit/Destructor.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/Destructor.java
@@ -1,0 +1,26 @@
+package org.rocstreaming.roctoolkit;
+
+/**
+ *  Interface providing a method for destruct a {@link NativeObject}.
+ */
+@FunctionalInterface
+interface Destructor {
+
+    /**
+     * Close {@link NativeObject}.
+     *
+     * This method can be called synchronously by the
+     * user or asynchronously by {@link AutoCloseThread}.
+     *
+     * <p style="color: red;">
+     * Note: It's important that this method is declared <code>static</code> and not as an
+     * instance method for avoiding object resurrection.
+     * </p>
+     *
+     * @param resource      {@link NativeObject#ptr NativeObject.ptr} to be closed.
+     *
+     * @throws Exception    if the {@link NativeObject} cannot be closed (for example
+     *                      for still opened {@link NativeObject} dependencies).
+     */
+    void close(long resource) throws Exception;
+}

--- a/src/main/java/org/rocstreaming/roctoolkit/NativeObject.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/NativeObject.java
@@ -1,18 +1,101 @@
 package org.rocstreaming.roctoolkit;
 
-class NativeObject {
+import static java.util.concurrent.TimeUnit.SECONDS;
 
-    private long ptr;
+/**
+ * A <code>NativeObject</code> represents an underlying native roc object.
+ */
+class NativeObject implements AutoCloseable {
 
-    NativeObject() {
-        ptr = 0L;
+    /**
+     * Maximum time to wait (in milliseconds) for joining {@link AutoCloseThread}.
+     */
+    private final static long MAX_JOIN_TIMEOUT_MS = SECONDS.toMillis(20L);
+
+    /**
+     * <code>NativeObject</code> finalizer thread.
+     */
+    private final static AutoCloseThread thread = AutoCloseThread.getInstance();
+
+    /**
+     *  Underlying roc object native pointer.
+     */
+    private final long ptr;
+
+    /**
+     *  Destructor method.
+     */
+    private final Destructor destructor;
+
+    /**
+     *  Reference to {@link NativeObjectReference}.
+     */
+    private final NativeObjectReference resource;
+
+    static {
+        RocLibrary.loadLibrary();
+        thread.start();
+
+        /* add a ShutdownHook for closing all NativeObjects that are still open */
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            thread.closeAll();
+            try {
+                thread.join(MAX_JOIN_TIMEOUT_MS);
+            } catch (InterruptedException e) {}
+        }));
     }
 
+    /**
+     * Construct a <code>NativeObject</code>.
+     *
+     * @param ptr               native pointer to a roc native object
+     * @param dependsOn         <code>NativeObject</code> dependency for
+     *                          finalization ordering
+     * @param destructor        destructor method for closing <code>NativeObject</code>.
+     */
+    protected NativeObject(long ptr, NativeObject dependsOn, Destructor destructor) {
+        this.ptr = ptr;
+        this.destructor = destructor;
+        this.resource = thread.add(this, dependsOn);
+    }
+
+    /**
+     * Construct a <code>NativeObject</code>.
+     *
+     * @param ptr               native pointer to a roc native object.
+     * @param destructor        destructor method for closing <code>NativeObject</code>.
+     */
+    protected NativeObject(long ptr, Destructor destructor) {
+        this(ptr, null, destructor);
+    }
+
+    /**
+     * Get <code>NativeObject</code> native pointer.
+     *
+     * @return                  the native roc object pointer associated to this
+     *                          <code>NativeObject</code>.
+     */
     long getPtr() {
         return this.ptr;
     }
 
-    static {
-        RocLibrary.loadLibrary();
+    /**
+     * Get <code>NativeObject</code> destructor.
+     *
+     * @return                  destructor method for closing <code>NativeObject</code>.
+     */
+    Destructor getDestructor() {
+        return this.destructor;
+    }
+
+    /**
+     * Close the native object and remove it from the {@link AutoCloseThread}.
+     *
+     * @throws Exception        if the underlying roc native object cannot be closed.
+     */
+    @Override
+    public void close() throws Exception {
+        thread.remove(resource);
+        resource.close();
     }
 }

--- a/src/main/java/org/rocstreaming/roctoolkit/NativeObjectReference.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/NativeObjectReference.java
@@ -1,0 +1,83 @@
+package org.rocstreaming.roctoolkit;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * <code>NativeObjectReference</code> is associated with a {@link NativeObject} and owns its entire lifetime;
+ *
+ * A <code>NativeObjectReference</code> contains necessary data for closing the native object
+ * after it becomes phantom reachable.
+ */
+class NativeObjectReference extends PhantomReference<NativeObject> implements AutoCloseable {
+
+    /**
+     *  Underlying roc object native pointer.
+     */
+    private final long ptr;
+
+    /**
+     *  Destructor method
+     */
+    private final Destructor destructor;
+
+    /**
+     *  Avoid {@link NativeObject} dependency to be garbage collected unless this
+     * <code>NativeObjectReference</code> is closed first (for example for avoiding
+     * {@link Context} to be closed before closing {@link Sender} or {@link Receiver}).
+     */
+    private final AtomicReference<NativeObject> dependsOn;
+
+    /**
+     * Construct a new <code>NativeObjectReference</code>.
+     *
+     * @param referent          {@link NativeObject} associated.
+     * @param dependsOn         {@link NativeObject} dependency for finalization ordering.
+     * @param queue             Reference queue containing phantom reachable native objects.
+     */
+    NativeObjectReference(NativeObject referent, NativeObject dependsOn,
+                        ReferenceQueue<? super NativeObject> queue) {
+        super(referent, queue);
+        this.ptr = referent.getPtr();
+        this.destructor = referent.getDestructor();
+        this.dependsOn = new AtomicReference<>(dependsOn);
+    }
+
+    /**
+     * Get {@link NativeObject} native pointer.
+     *
+     * @return      the native roc object pointer associated to this <code>NativeObjectReference</code>.
+     */
+    long getPtr() {
+        return ptr;
+    }
+
+    /**
+     * Get {@link NativeObject} destructor.
+     *
+     * @return      destructor method for closing {@link NativeObject}.
+     */
+    Destructor getDestructor() {
+        return destructor;
+    }
+
+    /**
+     * Get {@link NativeObject} dependency for finalization ordering.
+     *
+     * @return      an <code>Optional</code> describing the {@link NativeObject} dependency.
+     */
+    Optional<NativeObject> getDependsOn() {
+        return Optional.ofNullable(dependsOn.get());
+    }
+
+    /**
+     * Close the native object.
+     */
+    @Override
+    public void close() throws Exception {
+        destructor.close(ptr);
+        this.dependsOn.set(null);
+    }
+}

--- a/src/main/java/org/rocstreaming/roctoolkit/Receiver.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/Receiver.java
@@ -125,7 +125,22 @@ import java.io.IOException;
  * @see ReceiverConfig
  * @see java.lang.AutoCloseable
  */
-public class Receiver extends NativeObject implements AutoCloseable {
+public class Receiver extends NativeObject {
+
+    /**
+     * Validate receiver constructor parameters and open a new receiver if validation is successful.
+     *
+     * @param context                       should point to an opened context.
+     * @param config                        should point to an initialized config.
+     *
+     * @return                              the native roc receiver pointer.
+     * @throws IllegalArgumentException     if the arguments are invalid.
+     * @throws Exception                    if an error occured when creating the receiver.
+     */
+    private static long validate(Context context, ReceiverConfig config) throws IllegalArgumentException, Exception {
+        if (context == null || config == null) throw new IllegalArgumentException();
+        return open(context.getPtr(), config);
+    }
 
     /**
      * Open a new receiver.
@@ -136,12 +151,10 @@ public class Receiver extends NativeObject implements AutoCloseable {
      * @param config        should point to an initialized config.
      *
      * @throws IllegalArgumentException if the arguments are invalid.
-     * @throws IOException              if an error occured when creating the receiver.
+     * @throws Exception                if an error occured when creating the receiver.
      */
-    public Receiver(Context context, ReceiverConfig config) throws IllegalArgumentException, IOException {
-        super();
-        if (context == null || config == null) throw new IllegalArgumentException();
-        open(context.getPtr(), config);
+    public Receiver(Context context, ReceiverConfig config) throws IllegalArgumentException, Exception {
+        super(validate(context, config), context, Receiver::close);
     }
 
     /**
@@ -185,22 +198,8 @@ public class Receiver extends NativeObject implements AutoCloseable {
         readFloats(getPtr(), samples);
     }
 
-    /**
-     * Close the receiver.
-     *
-     * Deinitializes and deallocates the receiver, and detaches it from the context. The user
-     * should ensure that nobody uses the receiver during and after this call. If this
-     * function fails, the receiver is kept opened and attached to the context.
-     *
-     * @throws IOException if there was an error closing the receiver.
-     */
-    @Override
-    public void close() throws IOException {
-        close(getPtr());
-    }
-
-    private native void open(long contextPtr, ReceiverConfig config) throws IllegalArgumentException, IOException;
+    private static native long open(long contextPtr, ReceiverConfig config) throws IllegalArgumentException, Exception;
     private native void bind(long receiverPtr, int type, int protocol, Address address) throws IllegalArgumentException, IOException;
     private native void readFloats(long receiverPtr, float[] samples) throws IOException;
-    private native void close(long receiverPtr) throws IOException;
+    private static native void close(long receiverPtr) throws IOException;
 }

--- a/src/main/java/org/rocstreaming/roctoolkit/ReferenceCollector.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/ReferenceCollector.java
@@ -1,0 +1,99 @@
+package org.rocstreaming.roctoolkit;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Collect open {@link NativeObjectReference} for avoid beeing garbage collected.
+ *
+ * @param <T>       the type of {@link NativeObjectReference} to be collected.
+ */
+class ReferenceCollector<T extends NativeObjectReference> implements Iterable<T> {
+
+    /**
+     * References map indexed by their native pointers.
+     */
+    private final Map<Long, T> references;
+
+    /**
+     * Create a new <code>ReferenceCollector</code>.
+     */
+    ReferenceCollector() {
+        references = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Add a new reference to the collection.
+     *
+     * @param reference         reference to add.
+     */
+    void add(final T reference) {
+        references.put(reference.getPtr(), reference);
+    }
+
+    /**
+     * Remove a reference from the collection.
+     *
+     * @param reference         reference to remove.
+     */
+    void remove(final T reference) {
+        references.remove(reference.getPtr());
+    }
+
+    /**
+     * Get the number of referencies inside the collection.
+     *
+     * @return      number of referencies.
+     */
+    int size() {
+        return references.size();
+    }
+
+    /**
+     * Iterator over <code>ReferenceCollector</code> iterating referencies with dependencies
+     * ({@link NativeObjectReference#dependsOn}) firstly and secondly the referencies without
+     * dependencies.
+     */
+    class ReferenceCollectorIterator implements Iterator<T> {
+
+        /**
+         * Iterator over referencies with dependencies.
+         */
+        private Iterator<T> withDependencies;
+
+        /**
+         * Iterator over referencies without dependencies.
+         */
+        private Iterator<T> withoutDependencies;
+
+        /**
+         * Create a new <code>ReferenceCollectorIterator</code>.
+         */
+        ReferenceCollectorIterator() {
+            withDependencies = references.values().parallelStream()
+                            .filter(r -> r.getDependsOn().isPresent())
+                            .iterator();
+            withoutDependencies = references.values().parallelStream()
+                            .filter(r -> !r.getDependsOn().isPresent())
+                            .iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return withDependencies.hasNext() || withoutDependencies.hasNext();
+        }
+
+        @Override
+        public T next() {
+            if (withDependencies.hasNext()) return withDependencies.next();
+            if (withoutDependencies.hasNext()) return withoutDependencies.next();
+            return null;
+        }
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new ReferenceCollectorIterator();
+    }
+}

--- a/src/main/java/org/rocstreaming/roctoolkit/RocLibrary.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocLibrary.java
@@ -1,6 +1,8 @@
 package org.rocstreaming.roctoolkit;
 
 class RocLibrary {
+    private RocLibrary() {}
+
     static void loadLibrary() {
         System.loadLibrary("roc_jni");
     }

--- a/src/main/java/org/rocstreaming/roctoolkit/Sender.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/Sender.java
@@ -112,7 +112,23 @@ import java.io.IOException;
  * @see SenderConfig
  * @see java.lang.AutoCloseable
  */
-public class Sender extends NativeObject implements AutoCloseable {
+public class Sender extends NativeObject {
+
+    /**
+     * Validate sender constructor parameters and open a new sender if validation is successful.
+     *
+     * @param context                       should point to an opened context.
+     * @param config                        should point to an initialized config.
+     *
+     * @return                              the native roc sender pointer.
+     *
+     * @throws IllegalArgumentException     if the arguments are invalid.
+     * @throws Exception                    if an error occured when creating the sender.
+     */
+    private static long validate(Context context, SenderConfig config) throws IllegalArgumentException, Exception {
+        if (context == null || config == null) throw new IllegalArgumentException();
+        return open(context.getPtr(), config);
+    }
 
     /**
      * Open a new sender.
@@ -122,12 +138,10 @@ public class Sender extends NativeObject implements AutoCloseable {
      * @param config    should point to an initialized config.
      *
      * @throws IllegalArgumentException if the arguments are invalid.
-     * @throws IOException              if an error occured when creating the sender.
+     * @throws Exception                if an error occured when creating the sender.
      */
-    public Sender(Context context, SenderConfig config) throws IllegalArgumentException, IOException {
-        super();
-        if (context == null || config == null) throw new IllegalArgumentException();
-        open(context.getPtr(), config);
+    public Sender(Context context, SenderConfig config) throws IllegalArgumentException, Exception {
+        super(validate(context, config), context, Sender::close);
     }
 
     /**
@@ -190,23 +204,9 @@ public class Sender extends NativeObject implements AutoCloseable {
         writeFloats(getPtr(), samples);
     }
 
-    /**
-     * Close the sender.
-     *
-     * Deinitializes and deallocates the sender, and detaches it from the context. The user
-     * should ensure that nobody uses the sender during and after this call. If this
-     * function fails, the sender is kept opened and attached to the context.
-     *
-     * @throws IOException if there was an error closing the sender.
-     */
-    @Override
-    public void close() throws IOException {
-        close(getPtr());
-    }
-
-    private native void open(long contextPtr, SenderConfig config) throws IOException;
+    private static native long open(long contextPtr, SenderConfig config) throws IllegalArgumentException, Exception;
     private native void bind(long senderPtr, Address address) throws IllegalArgumentException, IOException;
     private native void connect(long senderPtr, int portType, int protocol, Address address) throws IOException;
     private native void writeFloats(long senderPtr, float[] samples) throws IOException;
-    private native void close(long senderPtr) throws IOException;
+    private static native void close(long senderPtr) throws IOException;
 }

--- a/src/test/java/org/rocstreaming/roctoolkit/ReceiverTest.java
+++ b/src/test/java/org/rocstreaming/roctoolkit/ReceiverTest.java
@@ -46,6 +46,7 @@ public class ReceiverTest {
     }
 
     @Test
+    @SuppressWarnings("resource")
     public void TestInvalidReceiverCreation() {
         assertThrows(IllegalArgumentException.class, () -> new Receiver(null, config));
         assertThrows(IllegalArgumentException.class, () -> new Receiver(context, null));

--- a/src/test/java/org/rocstreaming/roctoolkit/SenderTest.java
+++ b/src/test/java/org/rocstreaming/roctoolkit/SenderTest.java
@@ -64,6 +64,7 @@ public class SenderTest {
     }
 
     @Test
+    @SuppressWarnings("resource")
     public void TestInvalidSenderCreation() {
         assertThrows(IllegalArgumentException.class, () -> new Sender(null, config));
         assertThrows(IllegalArgumentException.class, () -> new Sender(context, null));


### PR DESCRIPTION
This PR would close #5.

The finalization is achieved with `PhantomReference` support since `java.lang.ref.Cleaner` is introduced only with Java 9.

Now each `NativeObject` is associated with a `NativeObjectReference` which contains all necessary data for closing the native object after it becomes phantom reachable.

For letting `Context` objects to not being garbage collected before `Sender` or `Receiver` are closed first, a reference to the context object is added to sender and receiver `NativeObjectReference` objects.