### PR TITLE
Switch to travis.com and fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,35 +19,27 @@ stages:
 jobs:
   include:
     - stage: Linux
+      dist: bionic
       jdk: openjdk8
+
     - stage: Linux
+      dist: bionic
       jdk: openjdk11
-    - stage: Linux
-      dist: xenial
-      jdk: openjdk8
-    - stage: Linux
-      dist: xenial
-      jdk: openjdk11
+
     - stage: macOS
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode11.6
       language: generic
       env:
         - JAVA_VERSION=8
+
     - stage: macOS
       os: osx
-      osx_image: xcode10.1
-      jdk: openjdk11
-    - stage: macOS
-      os: osx
-      osx_image: xcode11.3
+      osx_image: xcode11.6
       language: generic
       env:
-        - JAVA_VERSION=8
-    - stage: macOS
-      os: osx
-      osx_image: xcode11.3
-      jdk: openjdk11
+        - JAVA_VERSION=11
+
     - name: "android jdk8"
       stage: Android
       services:
@@ -60,12 +52,14 @@ jobs:
           paths:
             - android
             - $ROC_BASE_DIR
+
     - name: "android jdk11"
       stage: Android
       services:
         - docker
       env:
         - DIST=android JAVA_VERSION=11 ANDROID_API=28 ANDROID_BUILD_TOOLS_VERSION=28.0.3 ANDROID_NDK_VERSION=21.1.6352462 ROC_BASE_DIR=$HOME/roc
+
     - name: "android release"
       stage: Release
       workspaces:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JNI bindings for Roc Toolkit
 
-[![Build Status](https://travis-ci.org/roc-streaming/roc-java.svg?branch=master)](https://travis-ci.org/roc-streaming/roc-java)
+[![Build Status](https://travis-ci.com/roc-streaming/roc-java.svg?branch=master)](https://travis-ci.com/roc-streaming/roc-java)
 [![Android release](https://img.shields.io/bintray/v/roc-streaming/maven/roc-android?color=blue&label=aar)](https://bintray.com/roc-streaming/maven/roc-android/_latestVersion)
 
 This library provides JNI bindings for [Roc Toolkit](https://github.com/roc-streaming/roc-toolkit), a toolkit for real-time audio streaming over the network.

--- a/scripts/travis/osx/before_install.sh
+++ b/scripts/travis/osx/before_install.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-if [ "${JAVA_VERSION-}" = "8" ]; then
-    brew cask uninstall --force java
-    brew tap adoptopenjdk/openjdk
-    brew cask install adoptopenjdk/openjdk/adoptopenjdk8
-fi
+brew update
 
-brew unlink python@2
-brew list | grep -vE 'pkg-config|automake|libtool|cmake|xz|readline|openssl|sqlite|python|gdbm' | xargs brew pin
+brew tap AdoptOpenJDK/openjdk
+brew install --cask adoptopenjdk${JAVA_VERSION}
 
 brew install "scons"
 brew install "ragel"


### PR DESCRIPTION
travis.org is closing and suggests project to migrate to travis.com, which now is a single place for both oss and commercial projects.

I've migrated our travis project to travis.com. This PR updates README accordingly, and also fixes build and bumps OS versions.

travis.com have quite tight limits per organization. I've migrated all other repos, except roc-java, to github actions (see https://github.com/roc-streaming/roc-go/pull/32). Travis gave us 25k free credits (thanks to them!), which should last us a while. When we run out, we are supposed to request more credits via travis support. Or we can switch roc-java to github actions too.

The main problem with github actions is that their linux workers don't have KVM support and thus can't run emulator. Though, their osx workers can run it.