### PR TITLE
Cosmetic fixes in JNI code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,3 +75,28 @@ javadoc {
     options.overview = "${project.rootDir}/docs/javadoc/overview.html"
     options.memberLevel = System.getProperty("visibility") == "private" ? JavadocMemberLevel.PRIVATE : JavadocMemberLevel.PUBLIC
 }
+
+task clangFormat {
+    description = 'Formats all .h and .cpp files using clang-format'
+
+    doLast {
+        def hFiles = fileTree(dir: 'roc_jni', include: '**/*.h')
+        def cppFiles = fileTree(dir: 'roc_jni', include: '**/*.cpp')
+        def excludedFiles = fileTree(dir: 'roc_jni', include: '**/org_rocstreaming_roctoolkit_*')
+
+        hFiles = hFiles.minus(excludedFiles)
+        cppFiles = cppFiles.minus(excludedFiles)
+
+        hFiles.each { file ->
+            exec {
+                commandLine 'clang-format', '-i', file
+            }
+        }
+
+        cppFiles.each { file ->
+            exec {
+                commandLine 'clang-format', '-i', file
+            }
+        }
+    }
+}

--- a/roc_jni/.clang-format
+++ b/roc_jni/.clang-format
@@ -1,0 +1,12 @@
+# https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+#
+---
+BasedOnStyle: WebKit # http://www.webkit.org/coding/coding-style.html
+
+UseTab: Never
+IndentWidth: 4
+ColumnLimit: 100
+
+AllowShortIfStatementsOnASingleLine: Always
+BreakBeforeBraces: Attach
+SpaceAfterCStyleCast: true

--- a/roc_jni/src/main/cpp/channel_set.cpp
+++ b/roc_jni/src/main/cpp/channel_set.cpp
@@ -3,7 +3,7 @@
 
 #include <roc/config.h>
 
-roc_channel_set get_channel_set(JNIEnv *env, jobject jchannel_set) {
+roc_channel_set get_channel_set(JNIEnv* env, jobject jchannel_set) {
     jclass channelSetClass = NULL;
 
     channelSetClass = env->FindClass(CHANNEL_SET_CLASS);

--- a/roc_jni/src/main/cpp/clock_source.cpp
+++ b/roc_jni/src/main/cpp/clock_source.cpp
@@ -3,7 +3,7 @@
 
 #include <roc/config.h>
 
-roc_clock_source get_clock_source(JNIEnv *env, jobject jclock_source) {
+roc_clock_source get_clock_source(JNIEnv* env, jobject jclock_source) {
     jclass clockSourceClass = NULL;
 
     clockSourceClass = env->FindClass(CLOCK_SOURCE_CLASS);

--- a/roc_jni/src/main/cpp/common.cpp
+++ b/roc_jni/src/main/cpp/common.cpp
@@ -2,13 +2,15 @@
 
 #include <limits.h>
 
-int get_boolean_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error) {
+int get_boolean_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error) {
     jfieldID attrId = env->GetFieldID(clazz, attr_name, "Z");
     assert(attrId != NULL);
     return env->GetBooleanField(obj, attrId) == JNI_TRUE;
 }
 
-int get_int_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error) {
+int get_int_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error) {
     jfieldID attrId = env->GetFieldID(clazz, attr_name, "I");
     assert(attrId != NULL);
     jint ret = env->GetIntField(obj, attrId);
@@ -19,7 +21,8 @@ int get_int_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr
     return (int) ret;
 }
 
-unsigned int get_uint_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error) {
+unsigned int get_uint_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error) {
     jfieldID attrId = env->GetFieldID(clazz, attr_name, "I");
     assert(attrId != NULL);
     jint ret = env->GetIntField(obj, attrId);
@@ -30,13 +33,15 @@ unsigned int get_uint_field_value(JNIEnv *env, jclass clazz, jobject obj, const 
     return (unsigned int) ret;
 }
 
-long long get_llong_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error) {
+long long get_llong_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error) {
     jfieldID attrId = env->GetFieldID(clazz, attr_name, "J");
     assert(attrId != NULL);
     jlong ret = env->GetLongField(obj, attrId);
     return (long long) ret; // always safe (sizeof(long long) == sizeof(jlong))
 }
-unsigned long long get_ullong_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error) {
+unsigned long long get_ullong_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error) {
     jfieldID attrId = env->GetFieldID(clazz, attr_name, "J");
     assert(attrId != NULL);
     jlong ret = env->GetLongField(obj, attrId);
@@ -47,7 +52,7 @@ unsigned long long get_ullong_field_value(JNIEnv *env, jclass clazz, jobject obj
     return (unsigned long long) ret;
 }
 
-int get_enum_value(JNIEnv *env, jclass clazz, jobject enumObj) {
+int get_enum_value(JNIEnv* env, jclass clazz, jobject enumObj) {
     if (enumObj != NULL) {
         jfieldID attrId = env->GetFieldID(clazz, "value", "I");
         return env->GetIntField(enumObj, attrId);
@@ -55,7 +60,8 @@ int get_enum_value(JNIEnv *env, jclass clazz, jobject enumObj) {
     return 0;
 }
 
-jobject get_object_field(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, const char* attr_class_name) {
+jobject get_object_field(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, const char* attr_class_name) {
     jfieldID attrId = env->GetFieldID(clazz, attr_name, attr_class_name);
     assert(attrId != NULL);
     return env->GetObjectField(obj, attrId);

--- a/roc_jni/src/main/cpp/context.cpp
+++ b/roc_jni/src/main/cpp/context.cpp
@@ -1,12 +1,13 @@
 #include "org_rocstreaming_roctoolkit_Context.h"
+
 #include "common.h"
 
 #include <roc/context.h>
 
-#define CONTEXT_CLASS               PACKAGE_BASE_NAME "/Context"
-#define CONTEXT_CONFIG_CLASS        PACKAGE_BASE_NAME "/ContextConfig"
+#define CONTEXT_CLASS PACKAGE_BASE_NAME "/Context"
+#define CONTEXT_CONFIG_CLASS PACKAGE_BASE_NAME "/ContextConfig"
 
-char context_config_unmarshal(JNIEnv *env, roc_context_config* conf, jobject jconfig) {
+char context_config_unmarshal(JNIEnv* env, roc_context_config* conf, jobject jconfig) {
     jclass contextConfigClass = NULL;
     char err = 0;
 
@@ -15,14 +16,17 @@ char context_config_unmarshal(JNIEnv *env, roc_context_config* conf, jobject jco
 
     memset(conf, 0, sizeof(roc_context_config));
 
-    conf->max_packet_size = get_uint_field_value(env, contextConfigClass, jconfig, "maxPacketSize", &err);
+    conf->max_packet_size
+        = get_uint_field_value(env, contextConfigClass, jconfig, "maxPacketSize", &err);
     if (err) return err;
-    conf->max_frame_size = get_uint_field_value(env, contextConfigClass, jconfig, "maxFrameSize", &err);
+    conf->max_frame_size
+        = get_uint_field_value(env, contextConfigClass, jconfig, "maxFrameSize", &err);
     return err;
 }
 
-JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Context_open(JNIEnv *env, jclass contextClass, jobject config) {
-    roc_context*        context = NULL;
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Context_open(
+    JNIEnv* env, jclass contextClass, jobject config) {
+    roc_context* context = NULL;
     roc_context_config context_config = {};
 
     if (context_config_unmarshal(env, &context_config, config) != 0) {
@@ -40,7 +44,8 @@ JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Context_open(JNIEnv *en
     return (jlong) context;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Context_close(JNIEnv *env, jclass contextClass, jlong nativePtr) {
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Context_close(
+    JNIEnv* env, jclass contextClass, jlong nativePtr) {
 
     roc_context* context = (roc_context*) nativePtr;
 

--- a/roc_jni/src/main/cpp/endpoint.cpp
+++ b/roc_jni/src/main/cpp/endpoint.cpp
@@ -1,32 +1,33 @@
-#include <stdlib.h>
-
 #include "org_rocstreaming_roctoolkit_Endpoint.h"
+
 #include "common.h"
 #include "endpoint.h"
 #include "protocol.h"
 
 #include <roc/config.h>
 
-#define ENDPOINT_CLASS              PACKAGE_BASE_NAME "/Endpoint"
+#include <stdlib.h>
 
-int endpoint_unmarshal(JNIEnv *env, roc_endpoint** endpoint, jobject jendpoint) {
-    jclass          endpointClass = NULL;
-    jobject         tempObject = NULL;
-    jstring         jstr = NULL;
-    roc_protocol    protocol = (roc_protocol)0;
-    const char*     host = NULL;
-    int             port = 0;
-    const char*     resource = NULL;
-    char            err = 0;
+#define ENDPOINT_CLASS PACKAGE_BASE_NAME "/Endpoint"
+
+int endpoint_unmarshal(JNIEnv* env, roc_endpoint** endpoint, jobject jendpoint) {
+    jclass endpointClass = NULL;
+    jobject tempObject = NULL;
+    jstring jstr = NULL;
+    roc_protocol protocol = (roc_protocol) 0;
+    const char* host = NULL;
+    int port = 0;
+    const char* resource = NULL;
+    char err = 0;
 
     assert(*endpoint == NULL);
-    if (jendpoint == NULL)
-        return -1;
+    if (jendpoint == NULL) return -1;
 
     endpointClass = env->FindClass(ENDPOINT_CLASS);
     assert(endpointClass != NULL);
 
-    tempObject = get_object_field(env, endpointClass, jendpoint, "protocol", "L" PROTOCOL_CLASS ";");
+    tempObject
+        = get_object_field(env, endpointClass, jendpoint, "protocol", "L" PROTOCOL_CLASS ";");
     protocol = get_protocol(env, tempObject);
 
     if ((err = roc_endpoint_allocate(endpoint)) != 0) return err;
@@ -59,7 +60,8 @@ int endpoint_unmarshal(JNIEnv *env, roc_endpoint** endpoint, jobject jendpoint) 
         return err;
     }
 
-    jstr = (jstring) get_object_field(env, endpointClass, jendpoint, "resource", "Ljava/lang/String;");
+    jstr = (jstring) get_object_field(
+        env, endpointClass, jendpoint, "resource", "Ljava/lang/String;");
     if (jstr != NULL) {
         resource = env->GetStringUTFChars(jstr, 0);
         if ((err = roc_endpoint_set_resource(*endpoint, resource)) != 0) {
@@ -73,10 +75,10 @@ int endpoint_unmarshal(JNIEnv *env, roc_endpoint** endpoint, jobject jendpoint) 
     return 0;
 }
 
-void endpoint_set_protocol(JNIEnv *env, jobject endpoint, roc_protocol protocol) {
-    jclass      endpointClass = NULL;
-    jfieldID    attrId = NULL;
-    jobject     protocolObj = NULL;
+void endpoint_set_protocol(JNIEnv* env, jobject endpoint, roc_protocol protocol) {
+    jclass endpointClass = NULL;
+    jfieldID attrId = NULL;
+    jobject protocolObj = NULL;
 
     endpointClass = env->FindClass(ENDPOINT_CLASS);
     assert(endpointClass != NULL);
@@ -89,9 +91,9 @@ void endpoint_set_protocol(JNIEnv *env, jobject endpoint, roc_protocol protocol)
     env->SetObjectField(endpoint, attrId, protocolObj);
 }
 
-void endpoint_set_host(JNIEnv *env, jobject endpoint, const char* buf) {
-    jclass      endpointClass = NULL;
-    jfieldID    attrId = NULL;
+void endpoint_set_host(JNIEnv* env, jobject endpoint, const char* buf) {
+    jclass endpointClass = NULL;
+    jfieldID attrId = NULL;
 
     endpointClass = env->FindClass(ENDPOINT_CLASS);
     assert(endpointClass != NULL);
@@ -101,9 +103,9 @@ void endpoint_set_host(JNIEnv *env, jobject endpoint, const char* buf) {
     env->SetObjectField(endpoint, attrId, env->NewStringUTF(buf));
 }
 
-void endpoint_set_port(JNIEnv *env, jobject endpoint, int port) {
-    jclass      endpointClass = NULL;
-    jfieldID    attrId = NULL;
+void endpoint_set_port(JNIEnv* env, jobject endpoint, int port) {
+    jclass endpointClass = NULL;
+    jfieldID attrId = NULL;
 
     endpointClass = env->FindClass(ENDPOINT_CLASS);
     assert(endpointClass != NULL);
@@ -113,9 +115,9 @@ void endpoint_set_port(JNIEnv *env, jobject endpoint, int port) {
     env->SetIntField(endpoint, attrId, port);
 }
 
-void endpoint_set_resource(JNIEnv *env, jobject endpoint, const char* buf) {
-    jclass      endpointClass = NULL;
-    jfieldID    attrId = NULL;
+void endpoint_set_resource(JNIEnv* env, jobject endpoint, const char* buf) {
+    jclass endpointClass = NULL;
+    jfieldID attrId = NULL;
 
     endpointClass = env->FindClass(ENDPOINT_CLASS);
     assert(endpointClass != NULL);
@@ -125,14 +127,15 @@ void endpoint_set_resource(JNIEnv *env, jobject endpoint, const char* buf) {
     env->SetObjectField(endpoint, attrId, env->NewStringUTF(buf));
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_init(JNIEnv *env, jobject thisObj, jstring juri) {
-    roc_endpoint*   endpoint = NULL;
-    const char*     uri = NULL;
-    jclass          endpointClass = NULL;
-    roc_protocol    protocol = (roc_protocol)0;
-    int             port = 0;
-    char*           buf = NULL;
-    size_t          bufsz = 0;
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_init(
+    JNIEnv* env, jobject thisObj, jstring juri) {
+    roc_endpoint* endpoint = NULL;
+    const char* uri = NULL;
+    jclass endpointClass = NULL;
+    roc_protocol protocol = (roc_protocol) 0;
+    int port = 0;
+    char* buf = NULL;
+    size_t bufsz = 0;
 
     if (juri == NULL) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
@@ -140,7 +143,7 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_init(JNIEnv *en
         return;
     }
 
-    if (roc_endpoint_allocate(&endpoint) != 0 ) {
+    if (roc_endpoint_allocate(&endpoint) != 0) {
         jclass exceptionClass = env->FindClass(EXCEPTION);
         env->ThrowNew(exceptionClass, "Can't allocate roc_endpoint");
         return;
@@ -173,7 +176,7 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_init(JNIEnv *en
         env->ThrowNew(exceptionClass, "Can't get host from endpoint");
         return;
     }
-    buf = (char*)malloc(bufsz);
+    buf = (char*) malloc(bufsz);
     if (roc_endpoint_get_host(endpoint, buf, &bufsz) != 0) {
         free(buf);
         roc_endpoint_deallocate(endpoint);
@@ -192,7 +195,7 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_init(JNIEnv *en
     }
 
     if (roc_endpoint_get_resource(endpoint, NULL, &bufsz) == 0) {
-        buf = (char*)malloc(bufsz);
+        buf = (char*) malloc(bufsz);
         if (roc_endpoint_get_resource(endpoint, buf, &bufsz) == 0) {
             endpoint_set_resource(env, thisObj, buf);
         }
@@ -202,11 +205,12 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_init(JNIEnv *en
     roc_endpoint_deallocate(endpoint);
 }
 
-JNIEXPORT jstring JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_getUri(JNIEnv *env, jobject thisObj) {
-    roc_endpoint*   endpoint = NULL;
-    jstring         jstr = NULL;
-    char*           buf = NULL;
-    size_t          bufsz = 0;
+JNIEXPORT jstring JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_getUri(
+    JNIEnv* env, jobject thisObj) {
+    roc_endpoint* endpoint = NULL;
+    jstring jstr = NULL;
+    char* buf = NULL;
+    size_t bufsz = 0;
 
     if (endpoint_unmarshal(env, &endpoint, thisObj) != 0) {
         jclass exceptionClass = env->FindClass(EXCEPTION);
@@ -220,7 +224,7 @@ JNIEXPORT jstring JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_getUri(JNIEn
         env->ThrowNew(exceptionClass, "Can't get uri");
         return NULL;
     }
-    buf = (char*)malloc(bufsz);
+    buf = (char*) malloc(bufsz);
     if (roc_endpoint_get_uri(endpoint, buf, &bufsz) != 0) {
         free(buf);
         roc_endpoint_deallocate(endpoint);
@@ -235,10 +239,11 @@ JNIEXPORT jstring JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_getUri(JNIEn
     return jstr;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_validate(JNIEnv *env, jobject thisObj) {
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_validate(
+    JNIEnv* env, jobject thisObj) {
     roc_endpoint* endpoint = NULL;
-    char*         buf = NULL;
-    size_t        bufsz = 0;
+    char* buf = NULL;
+    size_t bufsz = 0;
 
     if (endpoint_unmarshal(env, &endpoint, thisObj) != 0) {
         jclass exceptionClass = env->FindClass(EXCEPTION);
@@ -251,7 +256,7 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Endpoint_validate(JNIEnv
         env->ThrowNew(exceptionClass, "Invalid roc_endpoint");
         return;
     }
-    buf = (char*)malloc(bufsz);
+    buf = (char*) malloc(bufsz);
     if (roc_endpoint_get_uri(endpoint, buf, &bufsz) != 0) {
         free(buf);
         roc_endpoint_deallocate(endpoint);

--- a/roc_jni/src/main/cpp/fec_encoding.cpp
+++ b/roc_jni/src/main/cpp/fec_encoding.cpp
@@ -3,7 +3,7 @@
 
 #include <roc/config.h>
 
-roc_fec_encoding get_fec_encoding(JNIEnv *env, jobject jfec_encoding) {
+roc_fec_encoding get_fec_encoding(JNIEnv* env, jobject jfec_encoding) {
     jclass fecEncodingClass = NULL;
 
     fecEncodingClass = env->FindClass(FEC_ENCODING_CLASS);

--- a/roc_jni/src/main/cpp/frame_encoding.cpp
+++ b/roc_jni/src/main/cpp/frame_encoding.cpp
@@ -1,7 +1,7 @@
 #include "frame_encoding.h"
 #include "common.h"
 
-roc_frame_encoding get_frame_encoding(JNIEnv *env, jobject jframe_encoding) {
+roc_frame_encoding get_frame_encoding(JNIEnv* env, jobject jframe_encoding) {
     jclass frameEncodingClass = NULL;
 
     frameEncodingClass = env->FindClass(FRAME_ENCODING_CLASS);

--- a/roc_jni/src/main/cpp/logger.cpp
+++ b/roc_jni/src/main/cpp/logger.cpp
@@ -1,45 +1,47 @@
 #include "org_rocstreaming_roctoolkit_Logger.h"
-#include "common.h"
 
-#include <mutex>
+#include "common.h"
 
 #include <roc/log.h>
 
-#define LOG_LEVEL_CLASS             PACKAGE_BASE_NAME "/LogLevel"
-#define LOG_HANDLER_CLASS           PACKAGE_BASE_NAME "/LogHandler"
+#include <mutex>
+
+#define LOG_LEVEL_CLASS PACKAGE_BASE_NAME "/LogLevel"
+#define LOG_HANDLER_CLASS PACKAGE_BASE_NAME "/LogHandler"
 
 static struct {
-    JavaVM*     vm;
-    jobject     callback;
-    jclass      logLevelClass;
-    jmethodID   methID;
-    std::mutex  mutex;
-} handler_args = {0};
+    JavaVM* vm;
+    jobject callback;
+    jclass logLevelClass;
+    jmethodID methID;
+    std::mutex mutex;
+} handler_args = { 0 };
 
 static const char* logLevelMapping(roc_log_level level) {
     const char* ret = "ERROR";
     switch (level) {
-        case ROC_LOG_NONE:
-            ret = "NONE";
-            break;
-        case ROC_LOG_ERROR:
-            ret = "ERROR";
-            break;
-        case ROC_LOG_INFO:
-            ret = "INFO";
-            break;
-        case ROC_LOG_DEBUG:
-            ret = "DEBUG";
-            break;
-        case ROC_LOG_TRACE:
-            ret = "TRACE";
-            break;
-        default: break;
+    case ROC_LOG_NONE:
+        ret = "NONE";
+        break;
+    case ROC_LOG_ERROR:
+        ret = "ERROR";
+        break;
+    case ROC_LOG_INFO:
+        ret = "INFO";
+        break;
+    case ROC_LOG_DEBUG:
+        ret = "DEBUG";
+        break;
+    case ROC_LOG_TRACE:
+        ret = "TRACE";
+        break;
+    default:
+        break;
     }
     return ret;
 };
 
-jint JNI_OnLoad(JavaVM *vm, void *reserved) {
+jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     JNIEnv* env = NULL;
     jclass tempLocalClassRef = NULL;
 
@@ -48,12 +50,13 @@ jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     }
 
     tempLocalClassRef = env->FindClass(LOG_LEVEL_CLASS);
-    handler_args.logLevelClass = (jclass) env->NewGlobalRef(tempLocalClassRef); // cache LogLevel class
+    handler_args.logLevelClass
+        = (jclass) env->NewGlobalRef(tempLocalClassRef); // cache LogLevel class
     env->DeleteLocalRef(tempLocalClassRef);
     return JNI_VERSION;
 }
 
-void JNI_OnUnload(JavaVM *vm, void *reserved) {
+void JNI_OnUnload(JavaVM* vm, void* reserved) {
     JNIEnv* env = NULL;
 
     vm->GetEnv((void**) &env, JNI_VERSION);
@@ -67,14 +70,14 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
 }
 
 void logger_handler(const roc_log_message* message, void* argument) {
-    JNIEnv*     env = NULL;
-    jfieldID    field = NULL;
-    jobject     levelObj = NULL;
-    jstring     jmodule = NULL;
-    jstring     jmess = NULL;
+    JNIEnv* env = NULL;
+    jfieldID field = NULL;
+    jobject levelObj = NULL;
+    jstring jmodule = NULL;
+    jstring jmess = NULL;
 
     handler_args.mutex.lock();
-    if(handler_args.vm == NULL || handler_args.callback == NULL || handler_args.methID == NULL) {
+    if (handler_args.vm == NULL || handler_args.callback == NULL || handler_args.methID == NULL) {
         handler_args.mutex.unlock();
         return;
     }
@@ -100,7 +103,8 @@ void logger_handler(const roc_log_message* message, void* argument) {
         return;
     }
 
-    field = env->GetStaticFieldID(handler_args.logLevelClass, logLevelMapping(message->level), "L" LOG_LEVEL_CLASS ";");
+    field = env->GetStaticFieldID(
+        handler_args.logLevelClass, logLevelMapping(message->level), "L" LOG_LEVEL_CLASS ";");
     levelObj = env->GetStaticObjectField(handler_args.logLevelClass, field);
 
     jmodule = env->NewStringUTF(message->module);
@@ -108,15 +112,15 @@ void logger_handler(const roc_log_message* message, void* argument) {
 
     env->CallVoidMethod(handler_args.callback, handler_args.methID, levelObj, jmodule, jmess);
 
-    if (attached)
-        handler_args.vm->DetachCurrentThread();
+    if (attached) handler_args.vm->DetachCurrentThread();
 
     handler_args.mutex.unlock();
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Logger_setLevel(JNIEnv *env, jclass clazz, jobject jlevel) {
-    jclass          logLevelClass = NULL;
-    roc_log_level   level = (roc_log_level)0;
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Logger_setLevel(
+    JNIEnv* env, jclass clazz, jobject jlevel) {
+    jclass logLevelClass = NULL;
+    roc_log_level level = (roc_log_level) 0;
 
     if (jlevel == NULL) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
@@ -128,9 +132,10 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Logger_setLevel(JNIEnv *
     roc_log_set_level(level);
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Logger_setCallback(JNIEnv *env, jclass clazz, jobject jhandler) {
-    jclass      logHandlerClass = NULL;
-    jmethodID   tmpMethodID = NULL;
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Logger_setCallback(
+    JNIEnv* env, jclass clazz, jobject jhandler) {
+    jclass logHandlerClass = NULL;
+    jmethodID tmpMethodID = NULL;
 
     if (jhandler == NULL) { // reset default callback (write to stderr)
         roc_log_set_handler(NULL, NULL);
@@ -138,9 +143,9 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Logger_setCallback(JNIEn
     }
 
     logHandlerClass = env->GetObjectClass(jhandler);
-    tmpMethodID = (jmethodID) env->GetMethodID(logHandlerClass, "log", "(L" LOG_LEVEL_CLASS ";Ljava/lang/String;Ljava/lang/String;)V");
-    if (tmpMethodID == NULL)
-        return;
+    tmpMethodID = (jmethodID) env->GetMethodID(
+        logHandlerClass, "log", "(L" LOG_LEVEL_CLASS ";Ljava/lang/String;Ljava/lang/String;)V");
+    if (tmpMethodID == NULL) return;
 
     handler_args.mutex.lock();
     env->GetJavaVM(&handler_args.vm);

--- a/roc_jni/src/main/cpp/packet_encoding.cpp
+++ b/roc_jni/src/main/cpp/packet_encoding.cpp
@@ -1,7 +1,7 @@
 #include "packet_encoding.h"
 #include "common.h"
 
-roc_packet_encoding get_packet_encoding(JNIEnv *env, jobject jpacket_encoding) {
+roc_packet_encoding get_packet_encoding(JNIEnv* env, jobject jpacket_encoding) {
     jclass packetEncodingClass = NULL;
 
     packetEncodingClass = env->FindClass(PACKET_ENCODING_CLASS);

--- a/roc_jni/src/main/cpp/protocol.cpp
+++ b/roc_jni/src/main/cpp/protocol.cpp
@@ -1,8 +1,8 @@
 #include "protocol.h"
 #include "common.h"
 
-roc_protocol get_protocol(JNIEnv *env, jobject jprotocol) {
-    jclass        protocolClass = NULL;
+roc_protocol get_protocol(JNIEnv* env, jobject jprotocol) {
+    jclass protocolClass = NULL;
 
     protocolClass = env->FindClass(PROTOCOL_CLASS);
     assert(protocolClass != NULL);
@@ -10,18 +10,20 @@ roc_protocol get_protocol(JNIEnv *env, jobject jprotocol) {
     return (roc_protocol) get_enum_value(env, protocolClass, jprotocol);
 }
 
-jobject get_protocol_enum(JNIEnv *env, roc_protocol protocol) {
-    jclass        protocolClass = NULL;
-    jobject       jprotocol = NULL;
-    jmethodID     getProtocolMethodID = NULL;
+jobject get_protocol_enum(JNIEnv* env, roc_protocol protocol) {
+    jclass protocolClass = NULL;
+    jobject jprotocol = NULL;
+    jmethodID getProtocolMethodID = NULL;
 
     protocolClass = env->FindClass(PROTOCOL_CLASS);
     assert(protocolClass != NULL);
 
-    getProtocolMethodID = env->GetStaticMethodID(protocolClass, "getByValue", "(I)L" PROTOCOL_CLASS ";");
+    getProtocolMethodID
+        = env->GetStaticMethodID(protocolClass, "getByValue", "(I)L" PROTOCOL_CLASS ";");
     assert(getProtocolMethodID != NULL);
 
-    jprotocol = (jobject) env->CallStaticObjectMethod(protocolClass, getProtocolMethodID, (jint) protocol);
+    jprotocol = (jobject) env->CallStaticObjectMethod(
+        protocolClass, getProtocolMethodID, (jint) protocol);
     assert(jprotocol != NULL);
     return jprotocol;
 }

--- a/roc_jni/src/main/cpp/receiver.cpp
+++ b/roc_jni/src/main/cpp/receiver.cpp
@@ -1,65 +1,77 @@
 #include "org_rocstreaming_roctoolkit_Receiver.h"
 
-#include "common.h"
-#include "clock_source.h"
 #include "channel_set.h"
+#include "clock_source.h"
+#include "common.h"
+#include "endpoint.h"
 #include "frame_encoding.h"
 #include "resampler_backend.h"
 #include "resampler_profile.h"
-#include "endpoint.h"
 
 #include <roc/receiver.h>
 
-#define RECEIVER_CLASS              PACKAGE_BASE_NAME "/Receiver"
-#define RECEIVER_CONFIG_CLASS       PACKAGE_BASE_NAME "/ReceiverConfig"
+#define RECEIVER_CLASS PACKAGE_BASE_NAME "/Receiver"
+#define RECEIVER_CONFIG_CLASS PACKAGE_BASE_NAME "/ReceiverConfig"
 
-char receiver_config_unmarshal(JNIEnv *env, roc_receiver_config* config, jobject jconfig) {
+char receiver_config_unmarshal(JNIEnv* env, roc_receiver_config* config, jobject jconfig) {
     jobject tempObject = NULL;
-    jclass  receiverConfigClass = NULL;
+    jclass receiverConfigClass = NULL;
     char err = 0;
 
     receiverConfigClass = env->FindClass(RECEIVER_CONFIG_CLASS);
     assert(receiverConfigClass != NULL);
 
-    config->frame_sample_rate = get_uint_field_value(env, receiverConfigClass, jconfig, "frameSampleRate", &err);
+    config->frame_sample_rate
+        = get_uint_field_value(env, receiverConfigClass, jconfig, "frameSampleRate", &err);
     if (err) return err;
 
-    tempObject = get_object_field(env, receiverConfigClass, jconfig, "frameChannels", "L" CHANNEL_SET_CLASS ";");
+    tempObject = get_object_field(
+        env, receiverConfigClass, jconfig, "frameChannels", "L" CHANNEL_SET_CLASS ";");
     if (tempObject == NULL) return 1;
     config->frame_channels = (roc_channel_set) get_channel_set(env, tempObject);
 
-    tempObject = get_object_field(env, receiverConfigClass, jconfig, "frameEncoding", "L" FRAME_ENCODING_CLASS ";");
+    tempObject = get_object_field(
+        env, receiverConfigClass, jconfig, "frameEncoding", "L" FRAME_ENCODING_CLASS ";");
     if (tempObject == NULL) return 1;
     config->frame_encoding = (roc_frame_encoding) get_frame_encoding(env, tempObject);
 
-    tempObject = get_object_field(env, receiverConfigClass, jconfig, "clockSource", "L" CLOCK_SOURCE_CLASS ";");
+    tempObject = get_object_field(
+        env, receiverConfigClass, jconfig, "clockSource", "L" CLOCK_SOURCE_CLASS ";");
     config->clock_source = get_clock_source(env, tempObject);
 
-    tempObject = get_object_field(env, receiverConfigClass, jconfig, "resamplerBackend", "L" RESAMPLER_BACKEND_CLASS ";");
+    tempObject = get_object_field(
+        env, receiverConfigClass, jconfig, "resamplerBackend", "L" RESAMPLER_BACKEND_CLASS ";");
     config->resampler_backend = get_resampler_backend(env, tempObject);
 
-    tempObject = get_object_field(env, receiverConfigClass, jconfig, "resamplerProfile", "L" RESAMPLER_PROFILE_CLASS ";");
+    tempObject = get_object_field(
+        env, receiverConfigClass, jconfig, "resamplerProfile", "L" RESAMPLER_PROFILE_CLASS ";");
     config->resampler_profile = (roc_resampler_profile) get_resampler_profile(env, tempObject);
 
-    config->target_latency = get_ullong_field_value(env, receiverConfigClass, jconfig, "targetLatency", &err);
+    config->target_latency
+        = get_ullong_field_value(env, receiverConfigClass, jconfig, "targetLatency", &err);
     if (err) return err;
-    config->max_latency_overrun = get_ullong_field_value(env, receiverConfigClass, jconfig, "maxLatencyOverrun", &err);
+    config->max_latency_overrun
+        = get_ullong_field_value(env, receiverConfigClass, jconfig, "maxLatencyOverrun", &err);
     if (err) return err;
-    config->max_latency_underrun = get_ullong_field_value(env, receiverConfigClass, jconfig, "maxLatencyUnderrun", &err);
+    config->max_latency_underrun
+        = get_ullong_field_value(env, receiverConfigClass, jconfig, "maxLatencyUnderrun", &err);
     if (err) return err;
-    config->no_playback_timeout = get_llong_field_value(env, receiverConfigClass, jconfig, "noPlaybackTimeout", &err);
+    config->no_playback_timeout
+        = get_llong_field_value(env, receiverConfigClass, jconfig, "noPlaybackTimeout", &err);
     if (err) return err;
-    config->broken_playback_timeout = get_llong_field_value(env, receiverConfigClass, jconfig, "brokenPlaybackTimeout", &err);
+    config->broken_playback_timeout
+        = get_llong_field_value(env, receiverConfigClass, jconfig, "brokenPlaybackTimeout", &err);
     if (err) return err;
-    config->breakage_detection_window = get_ullong_field_value(env, receiverConfigClass, jconfig, "breakageDetectionWindow", &err);
+    config->breakage_detection_window = get_ullong_field_value(
+        env, receiverConfigClass, jconfig, "breakageDetectionWindow", &err);
     return err;
 }
 
-JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Receiver_open(JNIEnv * env, jclass receiverClass,
-                    jlong contextPtr, jobject jconfig) {
-    roc_context*            context = NULL;
-    roc_receiver_config     receiverConfig = {};
-    roc_receiver*           receiver = NULL;
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Receiver_open(
+    JNIEnv* env, jclass receiverClass, jlong contextPtr, jobject jconfig) {
+    roc_context* context = NULL;
+    roc_receiver_config receiverConfig = {};
+    roc_receiver* receiver = NULL;
 
     context = (roc_context*) contextPtr;
 
@@ -78,15 +90,16 @@ JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Receiver_open(JNIEnv * 
     return (jlong) receiver;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_setMulticastGroup(JNIEnv * env, jobject thisObj,
-                    jlong receiverPtr, jint slot, jint interface, jstring jip) {
-    roc_receiver* receiver    = NULL;
-    const char*   ip = NULL;
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_setMulticastGroup(
+    JNIEnv* env, jobject thisObj, jlong receiverPtr, jint slot, jint interface, jstring jip) {
+    roc_receiver* receiver = NULL;
+    const char* ip = NULL;
 
     receiver = (roc_receiver*) receiverPtr;
     ip = env->GetStringUTFChars(jip, 0);
 
-    if (roc_receiver_set_multicast_group(receiver, (roc_slot) slot, (roc_interface) interface, ip) != 0) {
+    if (roc_receiver_set_multicast_group(receiver, (roc_slot) slot, (roc_interface) interface, ip)
+        != 0) {
         env->ReleaseStringUTFChars(jip, ip);
         jclass exceptionClass = env->FindClass(EXCEPTION);
         env->ThrowNew(exceptionClass, "Couldn't set multicast group");
@@ -95,11 +108,11 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_setMulticastGro
     env->ReleaseStringUTFChars(jip, ip);
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_bind(JNIEnv * env, jobject thisObj, jlong receiverPtr,
-                    jint slot, jint interface, jobject jendpoint) {
-    roc_receiver*   receiver    = NULL;
-    roc_endpoint*   endpoint    = NULL;
-    int             port        = 0;
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_bind(
+    JNIEnv* env, jobject thisObj, jlong receiverPtr, jint slot, jint interface, jobject jendpoint) {
+    roc_receiver* receiver = NULL;
+    roc_endpoint* endpoint = NULL;
+    int port = 0;
 
     receiver = (roc_receiver*) receiverPtr;
     if (endpoint_unmarshal(env, &endpoint, jendpoint) != 0) {
@@ -123,11 +136,12 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_bind(JNIEnv * e
     roc_endpoint_deallocate(endpoint);
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_readFloats(JNIEnv *env, jobject thisObj, jlong receiverPtr, jfloatArray jsamples) {
-    roc_receiver*       receiver = NULL;
-    roc_frame           frame = {};
-    jfloat*             samples = NULL;
-    jsize               len = 0;
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_readFloats(
+    JNIEnv* env, jobject thisObj, jlong receiverPtr, jfloatArray jsamples) {
+    roc_receiver* receiver = NULL;
+    roc_frame frame = {};
+    jfloat* samples = NULL;
+    jsize len = 0;
 
     if (jsamples == NULL) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
@@ -153,7 +167,8 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_readFloats(JNIE
     env->ReleaseFloatArrayElements(jsamples, samples, 0);
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_close(JNIEnv *env, jclass receiverClass, jlong receiverPtr) {
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Receiver_close(
+    JNIEnv* env, jclass receiverClass, jlong receiverPtr) {
 
     roc_receiver* receiver = (roc_receiver*) receiverPtr;
 

--- a/roc_jni/src/main/cpp/resampler_backend.cpp
+++ b/roc_jni/src/main/cpp/resampler_backend.cpp
@@ -3,7 +3,7 @@
 
 #include <roc/config.h>
 
-roc_resampler_backend get_resampler_backend(JNIEnv *env, jobject jresampler_backend) {
+roc_resampler_backend get_resampler_backend(JNIEnv* env, jobject jresampler_backend) {
     jclass resamplerBackendClass = NULL;
 
     resamplerBackendClass = env->FindClass(RESAMPLER_BACKEND_CLASS);

--- a/roc_jni/src/main/cpp/resampler_profile.cpp
+++ b/roc_jni/src/main/cpp/resampler_profile.cpp
@@ -3,7 +3,7 @@
 
 #include <roc/config.h>
 
-roc_resampler_profile get_resampler_profile(JNIEnv *env, jobject jresampler_profile) {
+roc_resampler_profile get_resampler_profile(JNIEnv* env, jobject jresampler_profile) {
     jclass resamplerProfileClass = NULL;
 
     resamplerProfileClass = env->FindClass(RESAMPLER_PROFILE_CLASS);

--- a/roc_jni/src/main/cpp/sender.cpp
+++ b/roc_jni/src/main/cpp/sender.cpp
@@ -1,21 +1,22 @@
 #include "org_rocstreaming_roctoolkit_Sender.h"
-#include "common.h"
-#include "clock_source.h"
+
 #include "channel_set.h"
+#include "clock_source.h"
+#include "common.h"
+#include "endpoint.h"
+#include "fec_encoding.h"
 #include "frame_encoding.h"
 #include "packet_encoding.h"
 #include "resampler_backend.h"
 #include "resampler_profile.h"
-#include "fec_encoding.h"
-#include "endpoint.h"
 
-#include <roc/sender.h>
 #include <roc/frame.h>
+#include <roc/sender.h>
 
-#define SENDER_CLASS                PACKAGE_BASE_NAME "/Sender"
-#define SENDER_CONFIG_CLASS         PACKAGE_BASE_NAME "/SenderConfig"
+#define SENDER_CLASS PACKAGE_BASE_NAME "/Sender"
+#define SENDER_CONFIG_CLASS PACKAGE_BASE_NAME "/SenderConfig"
 
-char sender_config_unmarshal(JNIEnv *env, roc_sender_config* config, jobject jconfig) {
+char sender_config_unmarshal(JNIEnv* env, roc_sender_config* config, jobject jconfig) {
     jobject tempObject = NULL;
     jclass senderConfigClass = NULL;
     char err = 0;
@@ -23,53 +24,68 @@ char sender_config_unmarshal(JNIEnv *env, roc_sender_config* config, jobject jco
     senderConfigClass = env->FindClass(SENDER_CONFIG_CLASS);
     assert(senderConfigClass != NULL);
 
-    config->frame_sample_rate = get_uint_field_value(env, senderConfigClass, jconfig, "frameSampleRate", &err);
+    config->frame_sample_rate
+        = get_uint_field_value(env, senderConfigClass, jconfig, "frameSampleRate", &err);
     if (err) return err;
 
-    tempObject = get_object_field(env, senderConfigClass, jconfig, "frameChannels", "L" CHANNEL_SET_CLASS ";");
+    tempObject = get_object_field(
+        env, senderConfigClass, jconfig, "frameChannels", "L" CHANNEL_SET_CLASS ";");
     if (tempObject == NULL) return 1;
     config->frame_channels = (roc_channel_set) get_channel_set(env, tempObject);
 
-    tempObject = get_object_field(env, senderConfigClass, jconfig, "frameEncoding", "L" FRAME_ENCODING_CLASS ";");
+    tempObject = get_object_field(
+        env, senderConfigClass, jconfig, "frameEncoding", "L" FRAME_ENCODING_CLASS ";");
     if (tempObject == NULL) return 1;
     config->frame_encoding = (roc_frame_encoding) get_frame_encoding(env, tempObject);
 
-    config->packet_sample_rate = get_uint_field_value(env, senderConfigClass, jconfig, "packetSampleRate", &err);
+    config->packet_sample_rate
+        = get_uint_field_value(env, senderConfigClass, jconfig, "packetSampleRate", &err);
     if (err) return err;
 
-    tempObject = get_object_field(env, senderConfigClass, jconfig, "packetChannels", "L" CHANNEL_SET_CLASS ";");
+    tempObject = get_object_field(
+        env, senderConfigClass, jconfig, "packetChannels", "L" CHANNEL_SET_CLASS ";");
     config->packet_channels = (roc_channel_set) get_channel_set(env, tempObject);
 
-    tempObject = get_object_field(env, senderConfigClass, jconfig, "packetEncoding", "L" PACKET_ENCODING_CLASS ";");
+    tempObject = get_object_field(
+        env, senderConfigClass, jconfig, "packetEncoding", "L" PACKET_ENCODING_CLASS ";");
     config->packet_encoding = (roc_packet_encoding) get_packet_encoding(env, tempObject);
 
-    config->packet_length = get_ullong_field_value(env, senderConfigClass, jconfig, "packetLength", &err);
+    config->packet_length
+        = get_ullong_field_value(env, senderConfigClass, jconfig, "packetLength", &err);
     if (err) return err;
-    config->packet_interleaving = get_uint_field_value(env, senderConfigClass, jconfig, "packetInterleaving", &err);
+    config->packet_interleaving
+        = get_uint_field_value(env, senderConfigClass, jconfig, "packetInterleaving", &err);
     if (err) return err;
 
-    tempObject = get_object_field(env, senderConfigClass, jconfig, "clockSource", "L" CLOCK_SOURCE_CLASS ";");
+    tempObject = get_object_field(
+        env, senderConfigClass, jconfig, "clockSource", "L" CLOCK_SOURCE_CLASS ";");
     config->clock_source = get_clock_source(env, tempObject);
 
-    tempObject = get_object_field(env, senderConfigClass, jconfig, "resamplerBackend", "L" RESAMPLER_BACKEND_CLASS ";");
+    tempObject = get_object_field(
+        env, senderConfigClass, jconfig, "resamplerBackend", "L" RESAMPLER_BACKEND_CLASS ";");
     config->resampler_backend = get_resampler_backend(env, tempObject);
 
-    tempObject = get_object_field(env, senderConfigClass, jconfig, "resamplerProfile", "L" RESAMPLER_PROFILE_CLASS ";");
+    tempObject = get_object_field(
+        env, senderConfigClass, jconfig, "resamplerProfile", "L" RESAMPLER_PROFILE_CLASS ";");
     config->resampler_profile = (roc_resampler_profile) get_resampler_profile(env, tempObject);
 
-    tempObject = get_object_field(env, senderConfigClass, jconfig, "fecEncoding", "L" FEC_ENCODING_CLASS ";");
+    tempObject = get_object_field(
+        env, senderConfigClass, jconfig, "fecEncoding", "L" FEC_ENCODING_CLASS ";");
     config->fec_encoding = (roc_fec_encoding) get_fec_encoding(env, tempObject);
 
-    config->fec_block_source_packets = get_uint_field_value(env, senderConfigClass, jconfig, "fecBlockSourcePackets", &err);
+    config->fec_block_source_packets
+        = get_uint_field_value(env, senderConfigClass, jconfig, "fecBlockSourcePackets", &err);
     if (err) return err;
-    config->fec_block_repair_packets = get_uint_field_value(env, senderConfigClass, jconfig, "fecBlockRepairPackets", &err);
+    config->fec_block_repair_packets
+        = get_uint_field_value(env, senderConfigClass, jconfig, "fecBlockRepairPackets", &err);
     return err;
 }
 
-JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Sender_open(JNIEnv *env, jclass senderClass, jlong contextPtr, jobject jconfig) {
-    roc_context*            context = NULL;
-    roc_sender_config       config = {};
-    roc_sender*             sender = NULL;
+JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Sender_open(
+    JNIEnv* env, jclass senderClass, jlong contextPtr, jobject jconfig) {
+    roc_context* context = NULL;
+    roc_sender_config config = {};
+    roc_sender* sender = NULL;
 
     context = (roc_context*) contextPtr;
 
@@ -88,7 +104,8 @@ JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Sender_open(JNIEnv *env
     return (jlong) sender;
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_close(JNIEnv *env, jclass senderClass, jlong senderPtr) {
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_close(
+    JNIEnv* env, jclass senderClass, jlong senderPtr) {
 
     roc_sender* sender = (roc_sender*) senderPtr;
 
@@ -98,14 +115,16 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_close(JNIEnv *env
     }
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_setOutgoingAddress(JNIEnv *env, jobject thisObj, jlong senderPtr, jint slot, jint interface, jstring jip) {
-    roc_sender*     sender = NULL;
-    const char*     ip = NULL;
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_setOutgoingAddress(
+    JNIEnv* env, jobject thisObj, jlong senderPtr, jint slot, jint interface, jstring jip) {
+    roc_sender* sender = NULL;
+    const char* ip = NULL;
 
     sender = (roc_sender*) senderPtr;
     ip = env->GetStringUTFChars(jip, 0);
 
-    if (roc_sender_set_outgoing_address(sender, (roc_slot) slot, (roc_interface) interface, ip) != 0) {
+    if (roc_sender_set_outgoing_address(sender, (roc_slot) slot, (roc_interface) interface, ip)
+        != 0) {
         env->ReleaseStringUTFChars(jip, ip);
         jclass exceptionClass = env->FindClass(EXCEPTION);
         env->ThrowNew(exceptionClass, "Couldn't set outgoing address");
@@ -114,10 +133,10 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_setOutgoingAddres
     env->ReleaseStringUTFChars(jip, ip);
 }
 
-
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_connect(JNIEnv *env, jobject thisObj, jlong senderPtr, jint slot, jint interface, jobject jendpoint) {
-    roc_endpoint*   endpoint = NULL;
-    roc_sender*     sender = NULL;
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_connect(
+    JNIEnv* env, jobject thisObj, jlong senderPtr, jint slot, jint interface, jobject jendpoint) {
+    roc_endpoint* endpoint = NULL;
+    roc_sender* sender = NULL;
 
     if (jendpoint == NULL) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
@@ -141,10 +160,11 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_connect(JNIEnv *e
     roc_endpoint_deallocate(endpoint);
 }
 
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_writeFloats(JNIEnv *env, jobject thisObj, jlong senderPtr, jfloatArray jsamples) {
-    jfloat*     samples = NULL;
-    jsize       len = 0;
-    roc_frame   frame = {};
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_writeFloats(
+    JNIEnv* env, jobject thisObj, jlong senderPtr, jfloatArray jsamples) {
+    jfloat* samples = NULL;
+    jsize len = 0;
+    roc_frame frame = {};
 
     if (jsamples == NULL) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);

--- a/roc_jni/src/main/headers/channel_set.h
+++ b/roc_jni/src/main/headers/channel_set.h
@@ -7,11 +7,12 @@ extern "C" {
 #endif
 
 #include "common.h"
+
 #include <roc/config.h>
 
-#define CHANNEL_SET_CLASS           PACKAGE_BASE_NAME "/ChannelSet"
+#define CHANNEL_SET_CLASS PACKAGE_BASE_NAME "/ChannelSet"
 
-roc_channel_set get_channel_set(JNIEnv *env, jobject jchannel_set);
+roc_channel_set get_channel_set(JNIEnv* env, jobject jchannel_set);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/channel_set.h
+++ b/roc_jni/src/main/headers/channel_set.h
@@ -2,9 +2,6 @@
 
 #ifndef CHANNEL_SET_H_
 #define CHANNEL_SET_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "common.h"
 
@@ -14,7 +11,4 @@ extern "C" {
 
 roc_channel_set get_channel_set(JNIEnv* env, jobject jchannel_set);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* CHANNEL_SET_H_ */

--- a/roc_jni/src/main/headers/channel_set.h
+++ b/roc_jni/src/main/headers/channel_set.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef CHANNEL_SET_H_
-#define CHANNEL_SET_H_
+#include <jni.h>
 
 #include "common.h"
 
@@ -10,5 +9,3 @@
 #define CHANNEL_SET_CLASS PACKAGE_BASE_NAME "/ChannelSet"
 
 roc_channel_set get_channel_set(JNIEnv* env, jobject jchannel_set);
-
-#endif /* CHANNEL_SET_H_ */

--- a/roc_jni/src/main/headers/clock_source.h
+++ b/roc_jni/src/main/headers/clock_source.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef CLOCK_SOURCE_H_
-#define CLOCK_SOURCE_H_
+#include <jni.h>
 
 #include "common.h"
 
@@ -10,5 +9,3 @@
 #define CLOCK_SOURCE_CLASS PACKAGE_BASE_NAME "/ClockSource"
 
 roc_clock_source get_clock_source(JNIEnv* env, jobject jclock_source);
-
-#endif /* CLOCK_SOURCE_H_ */

--- a/roc_jni/src/main/headers/clock_source.h
+++ b/roc_jni/src/main/headers/clock_source.h
@@ -2,9 +2,6 @@
 
 #ifndef CLOCK_SOURCE_H_
 #define CLOCK_SOURCE_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "common.h"
 
@@ -14,7 +11,4 @@ extern "C" {
 
 roc_clock_source get_clock_source(JNIEnv* env, jobject jclock_source);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* CLOCK_SOURCE_H_ */

--- a/roc_jni/src/main/headers/clock_source.h
+++ b/roc_jni/src/main/headers/clock_source.h
@@ -7,11 +7,12 @@ extern "C" {
 #endif
 
 #include "common.h"
+
 #include <roc/config.h>
 
-#define CLOCK_SOURCE_CLASS           PACKAGE_BASE_NAME "/ClockSource"
+#define CLOCK_SOURCE_CLASS PACKAGE_BASE_NAME "/ClockSource"
 
-roc_clock_source get_clock_source(JNIEnv *env, jobject jclock_source);
+roc_clock_source get_clock_source(JNIEnv* env, jobject jclock_source);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/common.h
+++ b/roc_jni/src/main/headers/common.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef COMMON_H_
-#define COMMON_H_
+#include <jni.h>
 
 #include <assert.h>
 #include <string.h>
@@ -30,5 +29,3 @@ void set_int_field_value(JNIEnv* env, jclass clazz, jobject obj, const char* att
 int get_enum_value(JNIEnv* env, jclass clazz, jobject enumObj);
 jobject get_object_field(
     JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, const char* attr_class_name);
-
-#endif /* COMMON_H_ */

--- a/roc_jni/src/main/headers/common.h
+++ b/roc_jni/src/main/headers/common.h
@@ -6,28 +6,33 @@
 extern "C" {
 #endif
 
-#include <string.h>
 #include <assert.h>
+#include <string.h>
 
-#define JNI_VERSION                     JNI_VERSION_1_6
+#define JNI_VERSION JNI_VERSION_1_6
 
-#define PACKAGE_BASE_NAME               "org/rocstreaming/roctoolkit"
-#define EXCEPTION                       "java/lang/Exception"
-#define ILLEGAL_ARGUMENTS_EXCEPTION     "java/lang/IllegalArgumentException"
-#define IO_EXCEPTION                    "java/io/IOException"
+#define PACKAGE_BASE_NAME "org/rocstreaming/roctoolkit"
+#define EXCEPTION "java/lang/Exception"
+#define ILLEGAL_ARGUMENTS_EXCEPTION "java/lang/IllegalArgumentException"
+#define IO_EXCEPTION "java/io/IOException"
 
-int get_boolean_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error);
+int get_boolean_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error);
 
-int get_int_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error);
-unsigned int get_uint_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error);
+int get_int_field_value(JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error);
+unsigned int get_uint_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error);
 
-long long get_llong_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error);
-unsigned long long get_ullong_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, char* error);
+long long get_llong_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error);
+unsigned long long get_ullong_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, char* error);
 
-void set_int_field_value(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, int value);
+void set_int_field_value(JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, int value);
 
-int get_enum_value(JNIEnv *env, jclass clazz, jobject enumObj);
-jobject get_object_field(JNIEnv *env, jclass clazz, jobject obj, const char* attr_name, const char* attr_class_name);
+int get_enum_value(JNIEnv* env, jclass clazz, jobject enumObj);
+jobject get_object_field(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, const char* attr_class_name);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/common.h
+++ b/roc_jni/src/main/headers/common.h
@@ -2,9 +2,6 @@
 
 #ifndef COMMON_H_
 #define COMMON_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <assert.h>
 #include <string.h>
@@ -34,7 +31,4 @@ int get_enum_value(JNIEnv* env, jclass clazz, jobject enumObj);
 jobject get_object_field(
     JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, const char* attr_class_name);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* COMMON_H_ */

--- a/roc_jni/src/main/headers/endpoint.h
+++ b/roc_jni/src/main/headers/endpoint.h
@@ -2,9 +2,6 @@
 
 #ifndef ENDPOINT_H_
 #define ENDPOINT_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <roc/endpoint.h>
 
@@ -12,7 +9,4 @@ int endpoint_unmarshal(JNIEnv* env, roc_endpoint** endpoint, jobject jendpoint);
 
 void endpoint_set_port(JNIEnv* env, jobject endpoint, int port);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* ENDPOINT_H_ */

--- a/roc_jni/src/main/headers/endpoint.h
+++ b/roc_jni/src/main/headers/endpoint.h
@@ -8,9 +8,9 @@ extern "C" {
 
 #include <roc/endpoint.h>
 
-int endpoint_unmarshal(JNIEnv *env, roc_endpoint** endpoint, jobject jendpoint);
+int endpoint_unmarshal(JNIEnv* env, roc_endpoint** endpoint, jobject jendpoint);
 
-void endpoint_set_port(JNIEnv *env, jobject endpoint, int port);
+void endpoint_set_port(JNIEnv* env, jobject endpoint, int port);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/endpoint.h
+++ b/roc_jni/src/main/headers/endpoint.h
@@ -1,12 +1,9 @@
-#include <jni.h>
+#pragma once
 
-#ifndef ENDPOINT_H_
-#define ENDPOINT_H_
+#include <jni.h>
 
 #include <roc/endpoint.h>
 
 int endpoint_unmarshal(JNIEnv* env, roc_endpoint** endpoint, jobject jendpoint);
 
 void endpoint_set_port(JNIEnv* env, jobject endpoint, int port);
-
-#endif /* ENDPOINT_H_ */

--- a/roc_jni/src/main/headers/fec_encoding.h
+++ b/roc_jni/src/main/headers/fec_encoding.h
@@ -2,9 +2,6 @@
 
 #ifndef FEC_ENCODING_H_
 #define FEC_ENCODING_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "common.h"
 
@@ -14,7 +11,4 @@ extern "C" {
 
 roc_fec_encoding get_fec_encoding(JNIEnv* env, jobject jfec_encoding);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* FEC_ENCODING_H_ */

--- a/roc_jni/src/main/headers/fec_encoding.h
+++ b/roc_jni/src/main/headers/fec_encoding.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef FEC_ENCODING_H_
-#define FEC_ENCODING_H_
+#include <jni.h>
 
 #include "common.h"
 
@@ -10,5 +9,3 @@
 #define FEC_ENCODING_CLASS PACKAGE_BASE_NAME "/FecEncoding"
 
 roc_fec_encoding get_fec_encoding(JNIEnv* env, jobject jfec_encoding);
-
-#endif /* FEC_ENCODING_H_ */

--- a/roc_jni/src/main/headers/fec_encoding.h
+++ b/roc_jni/src/main/headers/fec_encoding.h
@@ -7,11 +7,12 @@ extern "C" {
 #endif
 
 #include "common.h"
+
 #include <roc/config.h>
 
-#define FEC_ENCODING_CLASS              PACKAGE_BASE_NAME "/FecEncoding"
+#define FEC_ENCODING_CLASS PACKAGE_BASE_NAME "/FecEncoding"
 
-roc_fec_encoding get_fec_encoding(JNIEnv *env, jobject jfec_encoding);
+roc_fec_encoding get_fec_encoding(JNIEnv* env, jobject jfec_encoding);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/frame_encoding.h
+++ b/roc_jni/src/main/headers/frame_encoding.h
@@ -2,9 +2,6 @@
 
 #ifndef FRAME_ENCODING_H_
 #define FRAME_ENCODING_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "common.h"
 
@@ -14,7 +11,4 @@ extern "C" {
 
 roc_frame_encoding get_frame_encoding(JNIEnv* env, jobject jframe_encoding);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* FRAME_ENCODING_H_ */

--- a/roc_jni/src/main/headers/frame_encoding.h
+++ b/roc_jni/src/main/headers/frame_encoding.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef FRAME_ENCODING_H_
-#define FRAME_ENCODING_H_
+#include <jni.h>
 
 #include "common.h"
 
@@ -10,5 +9,3 @@
 #define FRAME_ENCODING_CLASS PACKAGE_BASE_NAME "/FrameEncoding"
 
 roc_frame_encoding get_frame_encoding(JNIEnv* env, jobject jframe_encoding);
-
-#endif /* FRAME_ENCODING_H_ */

--- a/roc_jni/src/main/headers/frame_encoding.h
+++ b/roc_jni/src/main/headers/frame_encoding.h
@@ -7,11 +7,12 @@ extern "C" {
 #endif
 
 #include "common.h"
+
 #include <roc/config.h>
 
-#define FRAME_ENCODING_CLASS        PACKAGE_BASE_NAME "/FrameEncoding"
+#define FRAME_ENCODING_CLASS PACKAGE_BASE_NAME "/FrameEncoding"
 
-roc_frame_encoding get_frame_encoding(JNIEnv *env, jobject jframe_encoding);
+roc_frame_encoding get_frame_encoding(JNIEnv* env, jobject jframe_encoding);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/packet_encoding.h
+++ b/roc_jni/src/main/headers/packet_encoding.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef PACKET_ENCODING_H_
-#define PACKET_ENCODING_H_
+#include <jni.h>
 
 #include "common.h"
 
@@ -10,5 +9,3 @@
 #define PACKET_ENCODING_CLASS PACKAGE_BASE_NAME "/PacketEncoding"
 
 roc_packet_encoding get_packet_encoding(JNIEnv* env, jobject jpacket_encoding);
-
-#endif /* PACKET_ENCODING_H_ */

--- a/roc_jni/src/main/headers/packet_encoding.h
+++ b/roc_jni/src/main/headers/packet_encoding.h
@@ -7,11 +7,12 @@ extern "C" {
 #endif
 
 #include "common.h"
+
 #include <roc/config.h>
 
-#define PACKET_ENCODING_CLASS        PACKAGE_BASE_NAME "/PacketEncoding"
+#define PACKET_ENCODING_CLASS PACKAGE_BASE_NAME "/PacketEncoding"
 
-roc_packet_encoding get_packet_encoding(JNIEnv *env, jobject jpacket_encoding);
+roc_packet_encoding get_packet_encoding(JNIEnv* env, jobject jpacket_encoding);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/packet_encoding.h
+++ b/roc_jni/src/main/headers/packet_encoding.h
@@ -2,9 +2,6 @@
 
 #ifndef PACKET_ENCODING_H_
 #define PACKET_ENCODING_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "common.h"
 
@@ -14,7 +11,4 @@ extern "C" {
 
 roc_packet_encoding get_packet_encoding(JNIEnv* env, jobject jpacket_encoding);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* PACKET_ENCODING_H_ */

--- a/roc_jni/src/main/headers/protocol.h
+++ b/roc_jni/src/main/headers/protocol.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef PROTOCOL_H_
-#define PROTOCOL_H_
+#include <jni.h>
 
 #include "common.h"
 
@@ -12,5 +11,3 @@
 roc_protocol get_protocol(JNIEnv* env, jobject jprotocol);
 
 jobject get_protocol_enum(JNIEnv* env, roc_protocol protocol);
-
-#endif /* PROTOCOL_H_ */

--- a/roc_jni/src/main/headers/protocol.h
+++ b/roc_jni/src/main/headers/protocol.h
@@ -1,6 +1,5 @@
 #include <jni.h>
 
-
 #ifndef PROTOCOL_H_
 #define PROTOCOL_H_
 #ifdef __cplusplus
@@ -8,13 +7,14 @@ extern "C" {
 #endif
 
 #include "common.h"
+
 #include <roc/config.h>
 
-#define PROTOCOL_CLASS              PACKAGE_BASE_NAME "/Protocol"
+#define PROTOCOL_CLASS PACKAGE_BASE_NAME "/Protocol"
 
-roc_protocol get_protocol(JNIEnv *env, jobject jprotocol);
+roc_protocol get_protocol(JNIEnv* env, jobject jprotocol);
 
-jobject get_protocol_enum(JNIEnv *env, roc_protocol protocol);
+jobject get_protocol_enum(JNIEnv* env, roc_protocol protocol);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/protocol.h
+++ b/roc_jni/src/main/headers/protocol.h
@@ -2,9 +2,6 @@
 
 #ifndef PROTOCOL_H_
 #define PROTOCOL_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "common.h"
 
@@ -16,7 +13,4 @@ roc_protocol get_protocol(JNIEnv* env, jobject jprotocol);
 
 jobject get_protocol_enum(JNIEnv* env, roc_protocol protocol);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* PROTOCOL_H_ */

--- a/roc_jni/src/main/headers/resampler_backend.h
+++ b/roc_jni/src/main/headers/resampler_backend.h
@@ -7,11 +7,12 @@ extern "C" {
 #endif
 
 #include "common.h"
+
 #include <roc/config.h>
 
-#define RESAMPLER_BACKEND_CLASS     PACKAGE_BASE_NAME "/ResamplerBackend"
+#define RESAMPLER_BACKEND_CLASS PACKAGE_BASE_NAME "/ResamplerBackend"
 
-roc_resampler_backend get_resampler_backend(JNIEnv *env, jobject jresampler_backend);
+roc_resampler_backend get_resampler_backend(JNIEnv* env, jobject jresampler_backend);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/resampler_backend.h
+++ b/roc_jni/src/main/headers/resampler_backend.h
@@ -2,9 +2,6 @@
 
 #ifndef RESAMPLER_BACKEND_H_
 #define RESAMPLER_BACKEND_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "common.h"
 
@@ -14,7 +11,4 @@ extern "C" {
 
 roc_resampler_backend get_resampler_backend(JNIEnv* env, jobject jresampler_backend);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* RESAMPLER_BACKEND_H_ */

--- a/roc_jni/src/main/headers/resampler_backend.h
+++ b/roc_jni/src/main/headers/resampler_backend.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef RESAMPLER_BACKEND_H_
-#define RESAMPLER_BACKEND_H_
+#include <jni.h>
 
 #include "common.h"
 
@@ -10,5 +9,3 @@
 #define RESAMPLER_BACKEND_CLASS PACKAGE_BASE_NAME "/ResamplerBackend"
 
 roc_resampler_backend get_resampler_backend(JNIEnv* env, jobject jresampler_backend);
-
-#endif /* RESAMPLER_BACKEND_H_ */

--- a/roc_jni/src/main/headers/resampler_profile.h
+++ b/roc_jni/src/main/headers/resampler_profile.h
@@ -1,7 +1,6 @@
-#include <jni.h>
+#pragma once
 
-#ifndef RESAMPLER_PROFILE_H_
-#define RESAMPLER_PROFILE_H_
+#include <jni.h>
 
 #include "common.h"
 
@@ -10,5 +9,3 @@
 #define RESAMPLER_PROFILE_CLASS PACKAGE_BASE_NAME "/ResamplerProfile"
 
 roc_resampler_profile get_resampler_profile(JNIEnv* env, jobject jresampler_profile);
-
-#endif /* RESAMPLER_PROFILE_H_ */

--- a/roc_jni/src/main/headers/resampler_profile.h
+++ b/roc_jni/src/main/headers/resampler_profile.h
@@ -7,11 +7,12 @@ extern "C" {
 #endif
 
 #include "common.h"
+
 #include <roc/config.h>
 
-#define RESAMPLER_PROFILE_CLASS     PACKAGE_BASE_NAME "/ResamplerProfile"
+#define RESAMPLER_PROFILE_CLASS PACKAGE_BASE_NAME "/ResamplerProfile"
 
-roc_resampler_profile get_resampler_profile(JNIEnv *env, jobject jresampler_profile);
+roc_resampler_profile get_resampler_profile(JNIEnv* env, jobject jresampler_profile);
 
 #ifdef __cplusplus
 }

--- a/roc_jni/src/main/headers/resampler_profile.h
+++ b/roc_jni/src/main/headers/resampler_profile.h
@@ -2,9 +2,6 @@
 
 #ifndef RESAMPLER_PROFILE_H_
 #define RESAMPLER_PROFILE_H_
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "common.h"
 
@@ -14,7 +11,4 @@ extern "C" {
 
 roc_resampler_profile get_resampler_profile(JNIEnv* env, jobject jresampler_profile);
 
-#ifdef __cplusplus
-}
-#endif
 #endif /* RESAMPLER_PROFILE_H_ */


### PR DESCRIPTION
This PR contains only stylistic mechanical changes:

* added `.clang-format` config, which describes style close to what is currently used in code
* added `gradlew clangFormat` task
* run code formatting
* remove `extern "C"` guards; they are not actually needed because guarded functions are used only from C++
* use `#pragma once` instead of old-style guards

I've set line width limit to 100 characters. Let me know if it's too low.