### PR TITLE
Enable compile_commands.json generation

### DIFF
--- a/roc_jni/.gitignore
+++ b/roc_jni/.gitignore
@@ -63,3 +63,7 @@ atlassian-ide-plugin.xml
 
 # NetBeans specific files/directories
 .nbattrs
+
+# LSP
+compile_commands.json
+.cache

--- a/roc_jni/CMakeLists.txt
+++ b/roc_jni/CMakeLists.txt
@@ -4,6 +4,8 @@ project(RocJni)
 
 set(CMAKE_CXX_STANDARD 11)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if(APPLE)
     # on macOs 10.14+ /usr/local/include and /usr/local/lib are not in SDK
     # compiler and linker PATH so let's add them explicitly
@@ -79,3 +81,10 @@ else()
         target_link_libraries(roc_jni -lroc)
     endif()
 endif()
+
+add_custom_command(TARGET roc_jni POST_BUILD
+    COMMENT "Copying compile_commands.json to project root"
+    COMMAND "${CMAKE_COMMAND}" -E copy
+        "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json"
+        "${PROJECT_SOURCE_DIR}/compile_commands.json"
+    )


### PR DESCRIPTION
* enable CMAKE_EXPORT_COMPILE_COMMANDS; it instructs CMake to generate compile_commands.json file, used by many editors for code navigation, auto complete, etc
* instruct cmake to copy compile_commands.json to jni project root; most editors look for that file there
* add compile_commands.json to .gitignore
* add .cache to .gitiginore (LSP cache; LSP can be used with emacs, vim, vscode, etc)