### PR TITLE
Rework error handling in JNI code

### DIFF
--- a/roc_jni/src/main/cpp/sender.cpp
+++ b/roc_jni/src/main/cpp/sender.cpp
@@ -17,66 +17,81 @@
 #define SENDER_CONFIG_CLASS PACKAGE_BASE_NAME "/SenderConfig"
 
 int sender_config_unmarshal(JNIEnv* env, roc_sender_config* config, jobject jconfig) {
-    jobject tempObject = NULL;
     jclass senderConfigClass = NULL;
+    jobject jobj = NULL;
     int err = 0;
 
     senderConfigClass = env->FindClass(SENDER_CONFIG_CLASS);
     assert(senderConfigClass != NULL);
 
+    // frame_sample_rate
     config->frame_sample_rate
         = get_uint_field_value(env, senderConfigClass, jconfig, "frameSampleRate", &err);
     if (err) return err;
 
-    tempObject = get_object_field(
+    // frame_channels
+    jobj = get_object_field(
         env, senderConfigClass, jconfig, "frameChannels", "L" CHANNEL_SET_CLASS ";");
-    if (tempObject == NULL) return 1;
-    config->frame_channels = (roc_channel_set) get_channel_set(env, tempObject);
+    if (jobj == NULL) return -1;
+    config->frame_channels = (roc_channel_set) get_channel_set(env, jobj);
 
-    tempObject = get_object_field(
+    // frame_encoding
+    jobj = get_object_field(
         env, senderConfigClass, jconfig, "frameEncoding", "L" FRAME_ENCODING_CLASS ";");
-    if (tempObject == NULL) return 1;
-    config->frame_encoding = (roc_frame_encoding) get_frame_encoding(env, tempObject);
+    if (jobj == NULL) return -1;
+    config->frame_encoding = (roc_frame_encoding) get_frame_encoding(env, jobj);
 
+    // packet_sample_rate
     config->packet_sample_rate
         = get_uint_field_value(env, senderConfigClass, jconfig, "packetSampleRate", &err);
     if (err) return err;
 
-    tempObject = get_object_field(
+    // packet_channels
+    jobj = get_object_field(
         env, senderConfigClass, jconfig, "packetChannels", "L" CHANNEL_SET_CLASS ";");
-    config->packet_channels = (roc_channel_set) get_channel_set(env, tempObject);
+    config->packet_channels = (roc_channel_set) get_channel_set(env, jobj);
 
-    tempObject = get_object_field(
+    // packet_encoding
+    jobj = get_object_field(
         env, senderConfigClass, jconfig, "packetEncoding", "L" PACKET_ENCODING_CLASS ";");
-    config->packet_encoding = (roc_packet_encoding) get_packet_encoding(env, tempObject);
+    config->packet_encoding = (roc_packet_encoding) get_packet_encoding(env, jobj);
 
+    // packet_length
     config->packet_length
         = get_ullong_field_value(env, senderConfigClass, jconfig, "packetLength", &err);
     if (err) return err;
+
+    // packet_interleaving
     config->packet_interleaving
         = get_uint_field_value(env, senderConfigClass, jconfig, "packetInterleaving", &err);
     if (err) return err;
 
-    tempObject = get_object_field(
+    // clock_source
+    jobj = get_object_field(
         env, senderConfigClass, jconfig, "clockSource", "L" CLOCK_SOURCE_CLASS ";");
-    config->clock_source = get_clock_source(env, tempObject);
+    config->clock_source = get_clock_source(env, jobj);
 
-    tempObject = get_object_field(
+    // resampler_backend
+    jobj = get_object_field(
         env, senderConfigClass, jconfig, "resamplerBackend", "L" RESAMPLER_BACKEND_CLASS ";");
-    config->resampler_backend = get_resampler_backend(env, tempObject);
+    config->resampler_backend = get_resampler_backend(env, jobj);
 
-    tempObject = get_object_field(
+    // resampler_profile
+    jobj = get_object_field(
         env, senderConfigClass, jconfig, "resamplerProfile", "L" RESAMPLER_PROFILE_CLASS ";");
-    config->resampler_profile = (roc_resampler_profile) get_resampler_profile(env, tempObject);
+    config->resampler_profile = (roc_resampler_profile) get_resampler_profile(env, jobj);
 
-    tempObject = get_object_field(
+    // fec_encoding
+    jobj = get_object_field(
         env, senderConfigClass, jconfig, "fecEncoding", "L" FEC_ENCODING_CLASS ";");
-    config->fec_encoding = (roc_fec_encoding) get_fec_encoding(env, tempObject);
+    config->fec_encoding = (roc_fec_encoding) get_fec_encoding(env, jobj);
 
+    // fec_block_source_packets
     config->fec_block_source_packets
         = get_uint_field_value(env, senderConfigClass, jconfig, "fecBlockSourcePackets", &err);
     if (err) return err;
 
+    // fec_block_repair_packets
     config->fec_block_repair_packets
         = get_uint_field_value(env, senderConfigClass, jconfig, "fecBlockRepairPackets", &err);
     if (err) return err;
@@ -94,17 +109,103 @@ JNIEXPORT jlong JNICALL Java_org_rocstreaming_roctoolkit_Sender_open(
 
     if (sender_config_unmarshal(env, &config, jconfig) != 0) {
         jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Bad arguments");
-        return (jlong) NULL;
+        env->ThrowNew(exceptionClass, "Bad config argument");
+        goto out;
     }
 
     if ((roc_sender_open(context, &config, &sender)) != 0) {
         jclass exceptionClass = env->FindClass(EXCEPTION);
         env->ThrowNew(exceptionClass, "Error opening sender");
-        return (jlong) NULL;
+        sender = NULL;
+        goto out;
     }
 
+out:
     return (jlong) sender;
+}
+
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_setOutgoingAddress(
+    JNIEnv* env, jobject thisObj, jlong senderPtr, jint slot, jint interface, jstring jip) {
+    roc_sender* sender = NULL;
+    const char* ip = NULL;
+
+    sender = (roc_sender*) senderPtr;
+
+    ip = env->GetStringUTFChars(jip, 0);
+    assert(ip != NULL);
+
+    if (roc_sender_set_outgoing_address(sender, (roc_slot) slot, (roc_interface) interface, ip)
+        != 0) {
+        jclass exceptionClass = env->FindClass(EXCEPTION);
+        env->ThrowNew(exceptionClass, "Can't set outgoing address");
+        goto out;
+    }
+
+out:
+    if (ip != NULL) env->ReleaseStringUTFChars(jip, ip);
+}
+
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_connect(
+    JNIEnv* env, jobject thisObj, jlong senderPtr, jint slot, jint interface, jobject jendpoint) {
+    roc_sender* sender = NULL;
+    roc_endpoint* endpoint = NULL;
+
+    sender = (roc_sender*) senderPtr;
+
+    if (jendpoint == NULL) {
+        jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
+        env->ThrowNew(exceptionClass, "Bad endpoint argument");
+        goto out;
+    }
+
+    if (endpoint_unmarshal(env, &endpoint, jendpoint) != 0) {
+        jclass exceptionClass = env->FindClass(IO_EXCEPTION);
+        env->ThrowNew(exceptionClass, "Error unmarshalling endpoint");
+        goto out;
+    }
+
+    if (roc_sender_connect(sender, (roc_slot) slot, (roc_interface) interface, endpoint) != 0) {
+        jclass exceptionClass = env->FindClass(IO_EXCEPTION);
+        env->ThrowNew(exceptionClass, "Error connecting sender");
+        goto out;
+    }
+
+out:
+    if (endpoint != NULL) {
+        roc_endpoint_deallocate(endpoint);
+    }
+}
+
+JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_writeFloats(
+    JNIEnv* env, jobject thisObj, jlong senderPtr, jfloatArray jsamples) {
+    roc_sender* sender = NULL;
+    jfloat* samples = NULL;
+    jsize len = 0;
+    roc_frame frame = {};
+
+    sender = (roc_sender*) senderPtr;
+
+    if (jsamples == NULL) {
+        jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
+        env->ThrowNew(exceptionClass, "Bad samples argument");
+        goto out;
+    }
+    samples = env->GetFloatArrayElements(jsamples, 0);
+    len = env->GetArrayLength(jsamples);
+    assert(samples != NULL);
+
+    memset(&frame, 0, sizeof(frame));
+    frame.samples = samples;
+    frame.samples_size = len * sizeof(float);
+
+    if (roc_sender_write(sender, &frame) != 0) {
+        jclass exceptionClass = env->FindClass(IO_EXCEPTION);
+        env->ThrowNew(exceptionClass, "Error writing frame");
+        goto out;
+    }
+
+out:
+    if (samples != NULL) env->ReleaseFloatArrayElements(jsamples, samples, 0);
 }
 
 JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_close(
@@ -116,80 +217,4 @@ JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_close(
         jclass exceptionClass = env->FindClass(IO_EXCEPTION);
         env->ThrowNew(exceptionClass, "Error closing sender");
     }
-}
-
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_setOutgoingAddress(
-    JNIEnv* env, jobject thisObj, jlong senderPtr, jint slot, jint interface, jstring jip) {
-    roc_sender* sender = NULL;
-    const char* ip = NULL;
-
-    sender = (roc_sender*) senderPtr;
-    ip = env->GetStringUTFChars(jip, 0);
-
-    if (roc_sender_set_outgoing_address(sender, (roc_slot) slot, (roc_interface) interface, ip)
-        != 0) {
-        env->ReleaseStringUTFChars(jip, ip);
-        jclass exceptionClass = env->FindClass(EXCEPTION);
-        env->ThrowNew(exceptionClass, "Couldn't set outgoing address");
-        return;
-    }
-    env->ReleaseStringUTFChars(jip, ip);
-}
-
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_connect(
-    JNIEnv* env, jobject thisObj, jlong senderPtr, jint slot, jint interface, jobject jendpoint) {
-    roc_endpoint* endpoint = NULL;
-    roc_sender* sender = NULL;
-
-    if (jendpoint == NULL) {
-        jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Bad arguments");
-        return;
-    }
-
-    sender = (roc_sender*) senderPtr;
-    if (endpoint_unmarshal(env, &endpoint, jendpoint) != 0) {
-        jclass exceptionClass = env->FindClass(IO_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Error unmarshalling endpoint");
-        return;
-    }
-
-    if (roc_sender_connect(sender, (roc_slot) slot, (roc_interface) interface, endpoint) != 0) {
-        roc_endpoint_deallocate(endpoint);
-        jclass exceptionClass = env->FindClass(IO_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Error with sender connect");
-        return;
-    }
-    roc_endpoint_deallocate(endpoint);
-}
-
-JNIEXPORT void JNICALL Java_org_rocstreaming_roctoolkit_Sender_writeFloats(
-    JNIEnv* env, jobject thisObj, jlong senderPtr, jfloatArray jsamples) {
-    jfloat* samples = NULL;
-    jsize len = 0;
-    roc_frame frame = {};
-
-    if (jsamples == NULL) {
-        jclass exceptionClass = env->FindClass(ILLEGAL_ARGUMENTS_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Bad arguments");
-        return;
-    }
-
-    samples = env->GetFloatArrayElements(jsamples, 0);
-    assert(samples != NULL);
-
-    len = env->GetArrayLength(jsamples);
-
-    memset(&frame, 0, sizeof(frame));
-
-    frame.samples = samples;
-    frame.samples_size = len * sizeof(float);
-
-    roc_sender* sender = (roc_sender*) senderPtr;
-    if (roc_sender_write(sender, &frame) != 0) {
-        jclass exceptionClass = env->FindClass(IO_EXCEPTION);
-        env->ThrowNew(exceptionClass, "Error sending frame");
-    }
-
-    env->ReleaseFloatArrayElements(jsamples, samples, 0);
 }

--- a/src/test/java/org/rocstreaming/roctoolkit/SenderTest.java
+++ b/src/test/java/org/rocstreaming/roctoolkit/SenderTest.java
@@ -175,7 +175,7 @@ public class SenderTest {
             sender.connect(Slot.DEFAULT, Interface.AUDIO_SOURCE, new Endpoint("rtp+rs8m://0.0.0.0:10001"));
             sender.connect(Slot.DEFAULT, Interface.AUDIO_REPAIR, new Endpoint("rs8m://0.0.0.0:10002"));
             Exception exception = assertThrows(Exception.class, () -> sender.setOutgoingAddress(Slot.DEFAULT, Interface.AUDIO_SOURCE, "127.0.0.1"));
-            assertEquals("Couldn't set outgoing address", exception.getMessage());
+            assertEquals("Can't set outgoing address", exception.getMessage());
         }
     }
 }


### PR DESCRIPTION
This patch reworks error handling in the following way:

```
some_function() {
    <declare vars>

    if (<error>) goto out;
    if (<error>) goto out;
    ...

    <set result to success>

out:
    if (<var allocated>) <release var>;
    if (<var allocated>) <release var>;

    return <result>;
}
```

In other words, function now has only one return path; that return path first frees all allocated resources, and then returns.

This approach is less error-prone because:

* you don't have to duplicate resource freeing in each return branch
* you don't need to track what resources should be freed in what branches

I also unified exception messages a bit and add comments to separate sections in large functions.