### PR TITLE
cAT test improvements

### DIFF
--- a/scripts/android/run_instrumented_tests.sh
+++ b/scripts/android/run_instrumented_tests.sh
@@ -4,4 +4,6 @@ set -euxo pipefail
 export TERM=dumb
 
 cd android
-./gradlew cAT --info --stacktrace
+
+./gradlew cAT --info --stacktrace || \
+    { adb logcat -t 500; exit 1; }

--- a/scripts/android_docker.sh
+++ b/scripts/android_docker.sh
@@ -131,6 +131,7 @@ then
 
     # start container in background mode, ignore its entrypoint
     run_cmd docker run --name roc_android \
+            --net host \
             -d --entrypoint "" \
             "${docker_args[@]}" \
            rocstreaming/env-android:jdk"${JAVA_VERSION}" \


### PR DESCRIPTION
* For some reason, networking does not work in env-android; I've added `--net host` and it helped
* Added `adb logcat` call when cAT tests failed; will help to debug failures on CI