### PR TITLE
Refinements in configs

### DIFF
--- a/roc_jni/src/main/impl/common.c
+++ b/roc_jni/src/main/impl/common.c
@@ -85,6 +85,31 @@ unsigned long long get_ullong_field_value(
     return (unsigned long long) ret;
 }
 
+long long get_duration_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, int* error) {
+    assert(env != NULL);
+    assert(clazz != NULL);
+    assert(attr_name != NULL);
+    assert(error != NULL);
+
+    jfieldID attrId = (*env)->GetFieldID(env, clazz, attr_name, "Ljava/time/Duration;");
+    assert(attrId != NULL);
+
+    jobject durationObj = (*env)->GetObjectField(env, obj, attrId);
+    if (durationObj == NULL) {
+        return 0;
+    }
+
+    jclass durationClass = (*env)->FindClass(env, "java/time/Duration");
+    assert(durationClass != NULL);
+
+    jmethodID toNanosMethodId = (*env)->GetMethodID(env, durationClass, "toNanos", "()J");
+    assert(toNanosMethodId != NULL);
+
+    jlong ret = (*env)->CallLongMethod(env, durationObj, toNanosMethodId);
+    return (long long) ret;
+}
+
 int get_enum_value(JNIEnv* env, jclass clazz, jobject enumObj) {
     assert(env != NULL);
     assert(clazz != NULL);

--- a/roc_jni/src/main/impl/common.h
+++ b/roc_jni/src/main/impl/common.h
@@ -24,7 +24,8 @@ long long get_llong_field_value(
 unsigned long long get_ullong_field_value(
     JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, int* error);
 
-void set_int_field_value(JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, int value);
+long long get_duration_field_value(
+    JNIEnv* env, jclass clazz, jobject obj, const char* attr_name, int* error);
 
 int get_enum_value(JNIEnv* env, jclass clazz, jobject enumObj);
 jobject get_object_field(

--- a/roc_jni/src/main/impl/receiver.c
+++ b/roc_jni/src/main/impl/receiver.c
@@ -56,31 +56,31 @@ static int receiver_config_unmarshal(JNIEnv* env, roc_receiver_config* config, j
 
     // target_latency
     config->target_latency
-        = get_ullong_field_value(env, receiverConfigClass, jconfig, "targetLatency", &err);
+        = get_duration_field_value(env, receiverConfigClass, jconfig, "targetLatency", &err);
     if (err) return err;
 
     // max_latency_overrun
     config->max_latency_overrun
-        = get_ullong_field_value(env, receiverConfigClass, jconfig, "maxLatencyOverrun", &err);
+        = get_duration_field_value(env, receiverConfigClass, jconfig, "maxLatencyOverrun", &err);
     if (err) return err;
 
     // max_latency_underrun
     config->max_latency_underrun
-        = get_ullong_field_value(env, receiverConfigClass, jconfig, "maxLatencyUnderrun", &err);
+        = get_duration_field_value(env, receiverConfigClass, jconfig, "maxLatencyUnderrun", &err);
     if (err) return err;
 
     // no_playback_timeout
     config->no_playback_timeout
-        = get_llong_field_value(env, receiverConfigClass, jconfig, "noPlaybackTimeout", &err);
+        = get_duration_field_value(env, receiverConfigClass, jconfig, "noPlaybackTimeout", &err);
     if (err) return err;
 
     // broken_playback_timeout
-    config->broken_playback_timeout
-        = get_llong_field_value(env, receiverConfigClass, jconfig, "brokenPlaybackTimeout", &err);
+    config->broken_playback_timeout = get_duration_field_value(
+        env, receiverConfigClass, jconfig, "brokenPlaybackTimeout", &err);
     if (err) return err;
 
     // breakage_detection_window
-    config->breakage_detection_window = get_ullong_field_value(
+    config->breakage_detection_window = get_duration_field_value(
         env, receiverConfigClass, jconfig, "breakageDetectionWindow", &err);
     if (err) return err;
 

--- a/roc_jni/src/main/impl/sender.c
+++ b/roc_jni/src/main/impl/sender.c
@@ -59,7 +59,7 @@ static int sender_config_unmarshal(JNIEnv* env, roc_sender_config* config, jobje
 
     // packet_length
     config->packet_length
-        = get_ullong_field_value(env, senderConfigClass, jconfig, "packetLength", &err);
+        = get_duration_field_value(env, senderConfigClass, jconfig, "packetLength", &err);
     if (err) return err;
 
     // packet_interleaving

--- a/src/main/java/org/rocstreaming/roctoolkit/Check.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/Check.java
@@ -1,5 +1,7 @@
 package org.rocstreaming.roctoolkit;
 
+import java.time.Duration;
+
 class Check {
     private Check() {
     }
@@ -14,6 +16,14 @@ class Check {
     static String notEmpty(String value, String name) {
         if (value == null || value.isEmpty()) {
             throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value;
+    }
+
+    static Duration notNegative(Duration value, String name) {
+        // Null ("unset") duration is fine, it's treated as zero on JNI side.
+        if (value != null && value.isNegative()) {
+            throw new IllegalArgumentException(name + " must not be negative");
         }
         return value;
     }

--- a/src/main/java/org/rocstreaming/roctoolkit/RocContextConfig.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocContextConfig.java
@@ -35,15 +35,6 @@ public class RocContextConfig {
     private int maxFrameSize;
 
     public static RocContextConfig.Builder builder() {
-        return new ValidationBuilder();
-    }
-
-    private static class ValidationBuilder extends RocContextConfig.Builder {
-        @Override
-        public RocContextConfig build() {
-            Check.notNegative(super.maxPacketSize, "maxPacketSize");
-            Check.notNegative(super.maxFrameSize, "maxFrameSize");
-            return super.build();
-        }
+        return new RocContextConfigValidator();
     }
 }

--- a/src/main/java/org/rocstreaming/roctoolkit/RocContextConfigValidator.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocContextConfigValidator.java
@@ -1,0 +1,15 @@
+package org.rocstreaming.roctoolkit;
+
+
+/**
+ * A <code>RocContextConfigValidator</code> adds validation to RocContextConfig builder.
+ */
+class RocContextConfigValidator extends RocContextConfig.Builder {
+    @Override
+    public RocContextConfig build() {
+        RocContextConfig config = super.build();
+        Check.notNegative(config.getMaxPacketSize(), "maxPacketSize");
+        Check.notNegative(config.getMaxFrameSize(), "maxFrameSize");
+        return config;
+    }
+}

--- a/src/main/java/org/rocstreaming/roctoolkit/RocReceiverConfig.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocReceiverConfig.java
@@ -1,5 +1,6 @@
 package org.rocstreaming.roctoolkit;
 
+import java.time.Duration;
 import lombok.*;
 
 /**
@@ -73,7 +74,7 @@ public class RocReceiverConfig {
      * If zero or unset, default value is used.
      * Should not be negative.
      */
-    private long targetLatency;
+    private Duration targetLatency;
 
     /**
      * Maximum delta between current and target latency, in nanoseconds.
@@ -82,7 +83,7 @@ public class RocReceiverConfig {
      * If zero or unset, default value is used.
      * Should not be negative.
      */
-    private long maxLatencyOverrun;
+    private Duration maxLatencyOverrun;
 
     /**
      * Maximum delta between target and current latency, in nanoseconds.
@@ -94,7 +95,7 @@ public class RocReceiverConfig {
      * If zero or unset, default value is used.
      * Should not be negative.
      */
-    private long maxLatencyUnderrun;
+    private Duration maxLatencyUnderrun;
 
     /**
      * Timeout for the lack of playback, in nanoseconds.
@@ -104,7 +105,7 @@ public class RocReceiverConfig {
      * If zero or unset, default value is used.
      * If negative, the timeout is disabled.
      */
-    private long noPlaybackTimeout;
+    private Duration noPlaybackTimeout;
 
     /**
      * Timeout for broken playback, in nanoseconds.
@@ -118,14 +119,14 @@ public class RocReceiverConfig {
      * If zero or unset, default value is used.
      * If negative, the timeout is disabled.
      */
-    private long brokenPlaybackTimeout;
+    private Duration brokenPlaybackTimeout;
 
     /**
      * Breakage detection window, in nanoseconds.
      * If zero or unset, default value is used.
      * Should not be negative.
      */
-    private long breakageDetectionWindow;
+    private Duration breakageDetectionWindow;
 
     public static RocReceiverConfig.Builder builder() {
         return new RocReceiverConfigValidator();

--- a/src/main/java/org/rocstreaming/roctoolkit/RocReceiverConfig.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocReceiverConfig.java
@@ -128,20 +128,6 @@ public class RocReceiverConfig {
     private long breakageDetectionWindow;
 
     public static RocReceiverConfig.Builder builder() {
-        return new ValidationBuilder();
-    }
-
-    private static class ValidationBuilder extends RocReceiverConfig.Builder {
-        @Override
-        public RocReceiverConfig build() {
-            Check.notNegative(super.frameSampleRate, "frameSampleRate");
-            Check.notNull(super.frameChannels, "frameChannels");
-            Check.notNull(super.frameEncoding, "frameEncoding");
-            Check.notNegative(super.targetLatency, "targetLatency");
-            Check.notNegative(super.maxLatencyOverrun, "maxLatencyOverrun");
-            Check.notNegative(super.maxLatencyUnderrun, "maxLatencyUnderrun");
-            Check.notNegative(super.breakageDetectionWindow, "breakageDetectionWindow");
-            return super.build();
-        }
+        return new RocReceiverConfigValidator();
     }
 }

--- a/src/main/java/org/rocstreaming/roctoolkit/RocReceiverConfigValidator.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocReceiverConfigValidator.java
@@ -1,0 +1,19 @@
+package org.rocstreaming.roctoolkit;
+
+/**
+ * A <code>RocReceiverConfigValidator</code> adds validation to RocReceiverConfig builder.
+ */
+class RocReceiverConfigValidator extends RocReceiverConfig.Builder {
+    @Override
+    public RocReceiverConfig build() {
+        RocReceiverConfig config = super.build();
+        Check.notNegative(config.getFrameSampleRate(), "frameSampleRate");
+        Check.notNull(config.getFrameChannels(), "frameChannels");
+        Check.notNull(config.getFrameEncoding(), "frameEncoding");
+        Check.notNegative(config.getTargetLatency(), "targetLatency");
+        Check.notNegative(config.getMaxLatencyOverrun(), "maxLatencyOverrun");
+        Check.notNegative(config.getMaxLatencyUnderrun(), "maxLatencyUnderrun");
+        Check.notNegative(config.getBreakageDetectionWindow(), "breakageDetectionWindow");
+        return config;
+    }
+}

--- a/src/main/java/org/rocstreaming/roctoolkit/RocSenderConfig.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocSenderConfig.java
@@ -122,21 +122,6 @@ public class RocSenderConfig {
     private int fecBlockRepairPackets;
 
     public static RocSenderConfig.Builder builder() {
-        return new ValidationBuilder();
+        return new RocSenderConfigValidator();
     }
-
-    private static class ValidationBuilder extends RocSenderConfig.Builder {
-        @Override
-        public RocSenderConfig build() {
-            Check.notNegative(super.frameSampleRate, "frameSampleRate");
-            Check.notNull(super.frameChannels, "frameChannels");
-            Check.notNull(super.frameEncoding, "frameEncoding");
-            Check.notNegative(super.packetSampleRate, "packetSampleRate");
-            Check.notNegative(super.packetLength, "packetLength");
-            Check.notNegative(super.fecBlockSourcePackets, "fecBlockSourcePackets");
-            Check.notNegative(super.fecBlockRepairPackets, "fecBlockRepairPackets");
-            return super.build();
-        }
-    }
-
 }

--- a/src/main/java/org/rocstreaming/roctoolkit/RocSenderConfig.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocSenderConfig.java
@@ -1,5 +1,6 @@
 package org.rocstreaming.roctoolkit;
 
+import java.time.Duration;
 import lombok.*;
 
 /**
@@ -63,7 +64,7 @@ public class RocSenderConfig {
      * If zero or unset, default value is used.
      * Should not be negative.
      */
-    private long packetLength;
+    private Duration packetLength;
 
     /**
      * Enable packet interleaving.

--- a/src/main/java/org/rocstreaming/roctoolkit/RocSenderConfigValidator.java
+++ b/src/main/java/org/rocstreaming/roctoolkit/RocSenderConfigValidator.java
@@ -1,0 +1,19 @@
+package org.rocstreaming.roctoolkit;
+
+/**
+ * A <code>RocSenderConfigValidator</code> adds validation to RocSenderConfig builder.
+ */
+class RocSenderConfigValidator extends RocSenderConfig.Builder {
+    @Override
+    public RocSenderConfig build() {
+        RocSenderConfig config = super.build();
+        Check.notNegative(config.getFrameSampleRate(), "frameSampleRate");
+        Check.notNull(config.getFrameChannels(), "frameChannels");
+        Check.notNull(config.getFrameEncoding(), "frameEncoding");
+        Check.notNegative(config.getPacketSampleRate(), "packetSampleRate");
+        Check.notNegative(config.getPacketLength(), "packetLength");
+        Check.notNegative(config.getFecBlockSourcePackets(), "fecBlockSourcePackets");
+        Check.notNegative(config.getFecBlockRepairPackets(), "fecBlockRepairPackets");
+        return config;
+    }
+}

--- a/src/test/java/org/rocstreaming/roctoolkit/RocReceiverConfigTest.java
+++ b/src/test/java/org/rocstreaming/roctoolkit/RocReceiverConfigTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.Duration;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,10 +23,10 @@ class RocReceiverConfigTest {
                 Arguments.of("frameSampleRate must not be negative", validBuilder().frameSampleRate(-1)),
                 Arguments.of("frameChannels must not be null", validBuilder().frameChannels(null)),
                 Arguments.of("frameEncoding must not be null", validBuilder().frameEncoding(null)),
-                Arguments.of("targetLatency must not be negative", validBuilder().targetLatency(-1)),
-                Arguments.of("maxLatencyOverrun must not be negative", validBuilder().maxLatencyOverrun(-1)),
-                Arguments.of("maxLatencyUnderrun must not be negative", validBuilder().maxLatencyUnderrun(-1)),
-                Arguments.of("breakageDetectionWindow must not be negative", validBuilder().breakageDetectionWindow(-1))
+                Arguments.of("targetLatency must not be negative", validBuilder().targetLatency(Duration.ofNanos(-1))),
+                Arguments.of("maxLatencyOverrun must not be negative", validBuilder().maxLatencyOverrun(Duration.ofNanos(-1))),
+                Arguments.of("maxLatencyUnderrun must not be negative", validBuilder().maxLatencyUnderrun(Duration.ofNanos(-1))),
+                Arguments.of("breakageDetectionWindow must not be negative", validBuilder().breakageDetectionWindow(Duration.ofNanos(-1)))
         );
     }
 

--- a/src/test/java/org/rocstreaming/roctoolkit/RocReceiverTest.java
+++ b/src/test/java/org/rocstreaming/roctoolkit/RocReceiverTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.Duration;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -49,12 +50,12 @@ public class RocReceiverTest extends BaseTest {
                 .clockSource(ClockSource.INTERNAL)
                 .resamplerBackend(ResamplerBackend.BUILTIN)
                 .resamplerProfile(ResamplerProfile.HIGH)
-                .targetLatency(1000)
-                .maxLatencyOverrun(500)
-                .maxLatencyUnderrun(500)
-                .noPlaybackTimeout(2000)
-                .brokenPlaybackTimeout(2000)
-                .breakageDetectionWindow(2000)
+                .targetLatency(Duration.ofNanos(1000))
+                .maxLatencyOverrun(Duration.ofNanos(500))
+                .maxLatencyUnderrun(Duration.ofNanos(500))
+                .noPlaybackTimeout(Duration.ofNanos(2000))
+                .brokenPlaybackTimeout(Duration.ofNanos(2000))
+                .breakageDetectionWindow(Duration.ofNanos(2000))
                 .build();
         assertDoesNotThrow(() -> {
             //noinspection EmptyTryBlock

--- a/src/test/java/org/rocstreaming/roctoolkit/RocSenderConfigTest.java
+++ b/src/test/java/org/rocstreaming/roctoolkit/RocSenderConfigTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.Duration;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,7 +26,7 @@ class RocSenderConfigTest {
                 Arguments.of("frameChannels must not be null", validBuilder().frameChannels(null)),
                 Arguments.of("frameEncoding must not be null", validBuilder().frameEncoding(null)),
                 Arguments.of("packetSampleRate must not be negative", validBuilder().packetSampleRate(-1)),
-                Arguments.of("packetLength must not be negative", validBuilder().packetLength(-1)),
+                Arguments.of("packetLength must not be negative", validBuilder().packetLength(Duration.ofNanos(-1))),
                 Arguments.of("fecBlockSourcePackets must not be negative", validBuilder().fecBlockSourcePackets(-1)),
                 Arguments.of("fecBlockRepairPackets must not be negative", validBuilder().fecBlockRepairPackets(-1))
         );

--- a/src/test/java/org/rocstreaming/roctoolkit/RocSenderTest.java
+++ b/src/test/java/org/rocstreaming/roctoolkit/RocSenderTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.stream.Stream;
 
 import static java.lang.Math.sin;
@@ -71,7 +72,7 @@ public class RocSenderTest extends BaseTest {
                 .packetSampleRate(44100)
                 .packetChannels(ChannelSet.STEREO)
                 .packetEncoding(PacketEncoding.AVP_L16)
-                .packetLength(2000)
+                .packetLength(Duration.ofNanos(2000))
                 .packetInterleaving(1)
                 .clockSource(ClockSource.INTERNAL)
                 .resamplerBackend(ResamplerBackend.BUILTIN)


### PR DESCRIPTION
1. Extract validators into separate files.

   We're going to make all RocXxxConfig.java files auto-generated. However, the validation part is hard to generate: there are no unified rule which fields should be non-null, non-negative, etc.

2. Fix #111